### PR TITLE
Compliance, Damping and Force range constraint API.

### DIFF
--- a/AGXUnity/Constraint.cs
+++ b/AGXUnity/Constraint.cs
@@ -49,6 +49,28 @@ namespace AGXUnity
     }
 
     /// <summary>
+    /// Translational degrees of freedom.
+    /// </summary>
+    public enum TranslationalDof
+    {
+      X,
+      Y,
+      Z,
+      All
+    }
+
+    /// <summary>
+    /// Rotational degrees of freedom.
+    /// </summary>
+    public enum RotationalDof
+    {
+      X,
+      Y,
+      Z,
+      All
+    }
+
+    /// <summary>
     /// Create a new constraint component given constraint type.
     /// </summary>
     /// <param name="type">Type of constraint.</param>
@@ -315,6 +337,133 @@ namespace AGXUnity
       }
 
       return null;
+    }
+
+    /// <summary>
+    /// Traverse ElementaryConstraintRowData instances of this constraints
+    /// ordinary elementary constraints.
+    /// </summary>
+    /// <typeparam name="T">Either TranslationalDof or RotationalDof.</typeparam>
+    /// <param name="callback">Callback for each valid row data instance.</param>
+    /// <param name="value">Enum value X, Y, Z or All.</param>
+    public void TraverseRowData<T>( Action<ElementaryConstraintRowData> callback, T value )
+      where T : struct
+    {
+      var rowParser = ConstraintUtils.ConstraintRowParser.Create( this );
+      var rows = typeof( T ) == typeof( TranslationalDof ) ?
+                   rowParser.TranslationalRows :
+                   rowParser.RotationalRows;
+
+      // Dof.All
+      if ( System.Convert.ToInt32( value ) > 2 ) {
+        foreach ( var data in rows )
+          if ( data != null )
+            callback( data.RowData );
+      }
+      else {
+        var data = rows[ System.Convert.ToInt32( value ) ];
+        if ( data != null )
+          callback( data.RowData );
+      }
+    }
+
+    /// <summary>
+    /// Set compliance to all ordinary degrees of freedom (not including controllers)
+    /// of this constraint.
+    /// </summary>
+    /// <param name="compliance">New compliance.</param>
+    public void SetCompliance( float compliance )
+    {
+      TraverseRowData( data => data.Compliance = compliance, TranslationalDof.All );
+      TraverseRowData( data => data.Compliance = compliance, RotationalDof.All );
+    }
+
+    /// <summary>
+    /// Set compliance to one or all translational ordinary degrees of freedom
+    /// (not including controllers) of this constraint.
+    /// </summary>
+    /// <param name="compliance">New compliance.</param>
+    /// <param name="dof">Specific translational degree of freedom or all.</param>
+    public void SetCompliance( float compliance, TranslationalDof dof )
+    {
+      TraverseRowData( data => data.Compliance = compliance, dof );
+    }
+
+    /// <summary>
+    /// Set compliance to one or all rotatinal ordinary degrees of freedom
+    /// (not including controllers) of this constraint.
+    /// </summary>
+    /// <param name="compliance">New compliance.</param>
+    /// <param name="dof">Specific rotational degree of freedom or all.</param>
+    public void SetCompliance( float compliance, RotationalDof dof )
+    {
+      TraverseRowData( data => data.Compliance = compliance, dof );
+    }
+
+    /// <summary>
+    /// Set damping to all ordinary degrees of freedom (not including controllers)
+    /// of this constraint.
+    /// </summary>
+    /// <param name="damping">New damping.</param>
+    public void SetDamping( float damping )
+    {
+      TraverseRowData( data => data.Damping = damping, TranslationalDof.All );
+      TraverseRowData( data => data.Damping = damping, RotationalDof.All );
+    }
+
+    /// <summary>
+    /// Set damping to one or all translational ordinary degrees of freedom
+    /// (not including controllers) of this constraint.
+    /// </summary>
+    /// <param name="damping">New damping.</param>
+    /// <param name="dof">Specific translational degree of freedom or all.</param>
+    public void SetDamping( float damping, TranslationalDof dof )
+    {
+      TraverseRowData( data => data.Damping = damping, dof );
+    }
+
+    /// <summary>
+    /// Set damping to one or all rotatinal ordinary degrees of freedom
+    /// (not including controllers) of this constraint.
+    /// </summary>
+    /// <param name="damping">New damping.</param>
+    /// <param name="dof">Specific rotational degree of freedom or all.</param>
+    public void SetDamping( float damping, RotationalDof dof )
+    {
+      TraverseRowData( data => data.Damping = damping, dof );
+    }
+
+    /// <summary>
+    /// Set force range to all ordinary degrees of freedom (not including controllers)
+    /// of this constraint.
+    /// </summary>
+    /// <param name="forceRange">New force range.</param>
+    public void SetForceRange( RangeReal forceRange )
+    {
+      TraverseRowData( data => data.ForceRange = forceRange, TranslationalDof.All );
+      TraverseRowData( data => data.ForceRange = forceRange, RotationalDof.All );
+    }
+
+    /// <summary>
+    /// Set force range to one or all translational ordinary degrees of freedom
+    /// (not including controllers) of this constraint.
+    /// </summary>
+    /// <param name="forceRange">New force range.</param>
+    /// <param name="dof">Specific translational degree of freedom or all.</param>
+    public void SetForceRange( RangeReal forceRange, TranslationalDof dof )
+    {
+      TraverseRowData( data => data.ForceRange = forceRange, dof );
+    }
+
+    /// <summary>
+    /// Set force range to one or all rotatinal ordinary degrees of freedom
+    /// (not including controllers) of this constraint.
+    /// </summary>
+    /// <param name="forceRange">New force range.</param>
+    /// <param name="dof">Specific rotational degree of freedom or all.</param>
+    public void SetForceRange( RangeReal forceRange, RotationalDof dof )
+    {
+      TraverseRowData( data => data.ForceRange = forceRange, dof );
     }
 
     /// <summary>

--- a/AGXUnity/ElementaryConstraintController.cs
+++ b/AGXUnity/ElementaryConstraintController.cs
@@ -8,6 +8,36 @@ namespace AGXUnity
   [HideInInspector]
   public class ElementaryConstraintController : ElementaryConstraint
   {
+    /// <summary>
+    /// Get/set the compliance of this controller.
+    /// </summary>
+    [HideInInspector]
+    public float Compliance
+    {
+      get { return RowData[ 0 ].Compliance; }
+      set { RowData[ 0 ].Compliance = value; }
+    }
+
+    /// <summary>
+    /// Get/set the damping of this controller (ignored for nonholonomic controllers).
+    /// </summary>
+    [HideInInspector]
+    public float Damping
+    {
+      get { return RowData[ 0 ].Damping; }
+      set { RowData[ 0 ].Damping = value; }
+    }
+
+    /// <summary>
+    /// Get/set force range of this controller.
+    /// </summary>
+    [HideInInspector]
+    public RangeReal ForceRange
+    {
+      get { return RowData[ 0 ].ForceRange; }
+      set { RowData[ 0 ].ForceRange = value; }
+    }
+
     public T As<T>( Constraint.ControllerType controllerType ) where T : ElementaryConstraintController
     {
       bool typeMatch = GetType() == typeof( T );

--- a/AGXUnity/RangeReal.cs
+++ b/AGXUnity/RangeReal.cs
@@ -41,6 +41,16 @@
     }
 
     /// <summary>
+    /// Construct given value of negative and positive bound, i.e.,
+    /// range = (-value, value).
+    /// </summary>
+    /// <param name="value">Negative and positive value of the range.</param>
+    public RangeReal( float value )
+      : this( -UnityEngine.Mathf.Abs( value ), UnityEngine.Mathf.Abs( value ) )
+    {
+    }
+
+    /// <summary>
     /// Copy constructor.
     /// </summary>
     public RangeReal( RangeReal other )

--- a/AGXUnity/RangeReal.cs
+++ b/AGXUnity/RangeReal.cs
@@ -30,6 +30,17 @@
     }
 
     /// <summary>
+    /// Construct given minimum and maximum values.
+    /// </summary>
+    /// <param name="min">Minimum/Lower bound value.</param>
+    /// <param name="max">Maximum/Upper bound value.</param>
+    public RangeReal( float min, float max )
+    {
+      Min = min;
+      Max = max;
+    }
+
+    /// <summary>
     /// Copy constructor.
     /// </summary>
     public RangeReal( RangeReal other )


### PR DESCRIPTION
Added Compliance, Damping and ForceRange properties to constraint controllers:
```C#
// Before:
hinge.GetController<TargetSpeedController>().RowData[ 0 ].Compliance = 1.0E-4f;
// Now:
hinge.GetController<TargetSpeedController>().Compliance = 1.0E-4f;
```

Added methods to change compliance, damping and force range in the ordinary elementary constraints of a constraint:
```C#
// Before:
// Many rows of code.
// Now:
// Compliance for translational X, Y and Z and rotational X and Y (Z is controlled).
hinge.SetCompliance( 1.0E-4 );
// Damping of all (X and Y) rotational degrees of freedom:
hinge.SetDamping( 0.33f, Constraint.RotationalDof.All );
// Force range of translational Y:
hinge.SetForceRange( new RangeReal( -1.0E3f, 1.0E3f ), Constraint.TranslationalDof.X );
```