### PR TITLE
Cable fix and made it easier to create constraints from scripts.

### DIFF
--- a/AGXUnity/AttachmentPair.cs
+++ b/AGXUnity/AttachmentPair.cs
@@ -63,6 +63,11 @@ namespace AGXUnity
     public ConstraintFrame ReferenceFrame
     {
       get { return m_referenceFrame; }
+      set
+      {
+        m_referenceFrame = value;
+        Synchronize();
+      }
     }
 
     /// <summary>
@@ -79,6 +84,11 @@ namespace AGXUnity
     public ConstraintFrame ConnectedFrame
     {
       get { return m_connectedFrame; }
+      set
+      {
+        m_connectedFrame = value;
+        Synchronize();
+      }
     }
 
     /// <summary>
@@ -143,7 +153,7 @@ namespace AGXUnity
     /// <summary>
     /// Update callback from some manager, synchronizing the frames if Synchronized == true.
     /// </summary>
-    public void Update()
+    public void Synchronize()
     {
       if ( Synchronized ) {
         m_connectedFrame.Position = m_referenceFrame.Position;

--- a/AGXUnity/Cable.cs
+++ b/AGXUnity/Cable.cs
@@ -434,6 +434,9 @@ namespace AGXUnity
 
       GetSimulation().add( Native );
 
+      if ( Properties != null )
+        Properties.GetInitialized<CableProperties>();
+
       SynchronizeProperties();
 
       return true;

--- a/AGXUnity/CableProperties.cs
+++ b/AGXUnity/CableProperties.cs
@@ -6,11 +6,10 @@ namespace AGXUnity
   [Serializable]
   public class CableProperty
   {
-    public static CableProperty Create( CableProperties.Direction dir, Action<CableProperties.Direction> onValueChanged )
+    public static CableProperty Create( CableProperties.Direction dir )
     {
       CableProperty property = new CableProperty();
       property.Direction = dir;
-      property.OnValueCanged += onValueChanged;
 
       return property;
     }
@@ -133,16 +132,21 @@ namespace AGXUnity
 
     public override void Destroy()
     {
+      foreach ( Direction dir in Directions )
+        this[ dir ].OnValueCanged -= OnPropertyChanged;
     }
 
     protected override void Construct()
     {
       foreach ( Direction dir in Directions )
-        this[ dir ] = CableProperty.Create( dir, OnPropertyChanged );
+        this[ dir ] = CableProperty.Create( dir );
     }
 
     protected override bool Initialize()
     {
+      foreach ( Direction dir in Directions )
+        this[ dir ].OnValueCanged += OnPropertyChanged;
+
       return true;
     }
 

--- a/AGXUnity/ConstraintFrame.cs
+++ b/AGXUnity/ConstraintFrame.cs
@@ -6,5 +6,101 @@ namespace AGXUnity
   [Serializable]
   public class ConstraintFrame : IFrame
   {
+    /// <summary>
+    /// Create constraint frame given parent, local position (parent frame) and
+    /// local rotation (parent frame)
+    /// </summary>
+    /// <param name="parent">Parent game object.</param>
+    /// <param name="localPosition">Local position in parent frame.</param>
+    /// <param name="localRotation">Local rotation in parent frame.</param>
+    /// <returns>New constraint frame.</returns>
+    public static ConstraintFrame CreateLocal( GameObject parent, Vector3 localPosition, Quaternion localRotation )
+    {
+      return new ConstraintFrame( parent, localPosition, localRotation );
+    }
+
+    /// <summary>
+    /// Create constraint frame given parent, local position (parent frame) and
+    /// local axis (parent frame)
+    /// </summary>
+    /// <param name="parent">Parent game object.</param>
+    /// <param name="localPosition">Local position in parent frame.</param>
+    /// <param name="localAxis">Local axis in parent frame.</param>
+    /// <returns>New constraint frame.</returns>
+    public static ConstraintFrame CreateLocal( GameObject parent, Vector3 localPosition, Vector3 localAxis )
+    {
+      return new ConstraintFrame( parent, localPosition, localAxis );
+    }
+
+    /// <summary>
+    /// Create constraint frame given parent, world position and world rotation.
+    /// </summary>
+    /// <param name="parent">Parent game object.</param>
+    /// <param name="worldPosition">World position.</param>
+    /// <param name="worldRotation">World rotation.</param>
+    /// <returns>New constraint frame.</returns>
+    public static ConstraintFrame CreateWorld( GameObject parent, Vector3 worldPosition, Quaternion worldRotation )
+    {
+      var frame = new ConstraintFrame( parent );
+      frame.Position = worldPosition;
+      frame.Rotation = worldRotation;
+      return frame;
+    }
+
+    /// <summary>
+    /// Create constraint frame given parent, world position and world axis.
+    /// </summary>
+    /// <param name="parent">Parent game object.</param>
+    /// <param name="worldPosition">World position.</param>
+    /// <param name="worldAxis">World axis.</param>
+    /// <returns>New constraint frame.</returns>
+    public static ConstraintFrame CreateWorld( GameObject parent, Vector3 worldPosition, Vector3 worldAxis )
+    {
+      return CreateWorld( parent, worldPosition, Quaternion.FromToRotation( Vector3.forward, worldAxis ) );
+    }
+
+    /// <summary>
+    /// Default constructor with null parent and zero position and identity rotation.
+    /// </summary>
+    public ConstraintFrame()
+    {
+    }
+
+    /// <summary>
+    /// Construct given parent. The transform of this frame will by default
+    /// be at center of the parent (this.Position == parent.transform.position,
+    /// this.Rotation == parent.transform.rotation).
+    /// </summary>
+    /// <param name="parent"></param>
+    public ConstraintFrame( GameObject parent )
+    {
+      SetParent( parent, false );
+    }
+
+    /// <summary>
+    /// Construct given parent, local position (parent frame) and
+    /// local rotation (parent frame)
+    /// </summary>
+    /// <param name="parent">Parent game object.</param>
+    /// <param name="localPosition">Local position in parent frame.</param>
+    /// <param name="localRotation">Local rotation in parent frame.</param>
+    public ConstraintFrame( GameObject parent, Vector3 localPosition, Quaternion localRotation )
+    {
+      SetParent( parent );
+      LocalPosition = localPosition;
+      LocalRotation = localRotation;
+    }
+
+    /// <summary>
+    /// Construct given parent, local position (parent frame) and
+    /// local axis (parent frame)
+    /// </summary>
+    /// <param name="parent">Parent game object.</param>
+    /// <param name="localPosition">Local position in parent frame.</param>
+    /// <param name="localAxis">Local axis in parent frame.</param>
+    public ConstraintFrame( GameObject parent, Vector3 localPosition, Vector3 localAxis )
+      : this( parent, localPosition, Quaternion.FromToRotation( Vector3.forward, localAxis ) )
+    {
+    }
   }
 }

--- a/AGXUnity/Rendering/DebugRenderManager.cs
+++ b/AGXUnity/Rendering/DebugRenderManager.cs
@@ -303,7 +303,7 @@ namespace AGXUnity.Rendering
       );
 
       FindObjectsOfType<Constraint>().ToList().ForEach(
-        constraint => constraint.AttachmentPair.Update()
+        constraint => constraint.AttachmentPair.Synchronize()
       );
 
       List<GameObject> gameObjectsToDestroy = new List<GameObject>();

--- a/Editor/AGXUnityEditor/Tools/ConstraintCreateTool.cs
+++ b/Editor/AGXUnityEditor/Tools/ConstraintCreateTool.cs
@@ -74,7 +74,7 @@ namespace AGXUnityEditor.Tools
       GUI.Separator3D();
 
       AttachmentFrameTool.OnPreTargetMembersGUI( skin );
-      AttachmentFrameTool.AttachmentPair.Update();
+      AttachmentFrameTool.AttachmentPair.Synchronize();
 
       m_createConstraintData.CollisionState = ConstraintTool.ConstraintCollisionsStateGUI( m_createConstraintData.CollisionState, skin );
       m_createConstraintData.SolveType = ConstraintTool.ConstraintSolveTypeGUI( m_createConstraintData.SolveType, skin );


### PR DESCRIPTION
* Synchronization of cable properties of an initialized cable when the changes were made in the cable properties asset GUI (i.e., not through the Cable GUI) fix - closes #8.
* Made it easier to create constraints from script by using two `AGXUnity.ConstraintFrame` instances:
```c#
// - ConstraintFrame.CreateWorld given world position and direction/rotation.
// - ConstraintFrame.CreateLocal with position and direction/rotation given
//   in the frame of the parent.
var f1 = ConstraintFrame.CreateWorld( parentGameObject1, worldPosition, worldDirection );
var f2 = ConstraintFrame.CreateWorld( parentGameObject2, worldPosition, worldDirection );
var constraint = Constraint.Create( ConstraintType.Hinge, f1, f2 );
```