### PR TITLE
Allow stepping simulation explicitly

### DIFF
--- a/AGXUnity/Simulation.cs
+++ b/AGXUnity/Simulation.cs
@@ -18,7 +18,13 @@ namespace AGXUnity
     /// </summary>
     private agxSDK.Simulation m_simulation = null;
 	
-    public bool EnableAutomaticStepping = true;
+    [SerializeField]
+    private bool m_enableAutomaticStepping = true;
+    public bool EnableAutomaticStepping
+    {
+      get { return m_enableAutomaticStepping; }
+      set { m_enableAutomaticStepping = value; }
+    }
     
     public static float DefaultTimeStep { get { return Time.fixedDeltaTime; } }
 

--- a/AGXUnity/Simulation.cs
+++ b/AGXUnity/Simulation.cs
@@ -171,8 +171,8 @@ namespace AGXUnity
 
     private void FixedUpdate()
     {
-      if (EnableAutomaticStepping)
-    	DoStep();
+      if (m_enableAutomaticStepping)
+        DoStep();
     }		
 
     public void DoStep()

--- a/AGXUnity/Simulation.cs
+++ b/AGXUnity/Simulation.cs
@@ -18,8 +18,17 @@ namespace AGXUnity
     /// </summary>
     private agxSDK.Simulation m_simulation = null;
 	
+    /// <summary>
+    /// Control automatic stepping of simulation.
+    /// Also see the EnableAutomaticStepping property.
+    /// </summary>
     [SerializeField]
     private bool m_enableAutomaticStepping = true;
+
+    /// <summary>
+    /// Set to true to enable automatic stepping during FixedUpdate.
+    /// If set to false, the DoStep() method will have to be manually called.
+    /// </summary>
     public bool EnableAutomaticStepping
     {
       get { return m_enableAutomaticStepping; }

--- a/AGXUnity/Simulation.cs
+++ b/AGXUnity/Simulation.cs
@@ -17,6 +17,8 @@ namespace AGXUnity
     /// Native instance.
     /// </summary>
     private agxSDK.Simulation m_simulation = null;
+	
+	public bool EnableAutomaticStepping = true;
     
     public static float DefaultTimeStep { get { return Time.fixedDeltaTime; } }
 
@@ -152,7 +154,13 @@ namespace AGXUnity
       return base.Initialize();
     }
 
-    protected void FixedUpdate()
+    private void FixedUpdate()
+    {
+      if (EnableAutomaticStepping)
+    	DoStep()
+    }		
+
+    public void DoStep()
     {
       if ( !NativeHandler.Instance.HasValidLicense )
         return;

--- a/AGXUnity/Simulation.cs
+++ b/AGXUnity/Simulation.cs
@@ -18,7 +18,7 @@ namespace AGXUnity
     /// </summary>
     private agxSDK.Simulation m_simulation = null;
 	
-	public bool EnableAutomaticStepping = true;
+    public bool EnableAutomaticStepping = true;
     
     public static float DefaultTimeStep { get { return Time.fixedDeltaTime; } }
 
@@ -157,7 +157,7 @@ namespace AGXUnity
     private void FixedUpdate()
     {
       if (EnableAutomaticStepping)
-    	DoStep()
+    	DoStep();
     }		
 
     public void DoStep()


### PR DESCRIPTION
Adds the `EnableAutomaticStepping` variable which will control whether the simulation steps during FixedUpdate or not. If the property is set to `false`, the `DoStep()` method will have to be called explicitly.