### PR TITLE
Disabling imported objects when reading prefab from .agx file

### DIFF
--- a/AGXUnity/RigidBody.cs
+++ b/AGXUnity/RigidBody.cs
@@ -278,7 +278,10 @@ namespace AGXUnity
       MassProperties.RestoreLocalDataFrom( native.getMassProperties() );
 
       enabled                = native.getEnable();
-      MotionControl          = native.getMotionControl();
+      // Should the body be enabled?
+      gameObject.SetActive(native.isEnabled());
+
+      MotionControl = native.getMotionControl();
       HandleAsParticle       = native.getHandleAsParticle();
       LinearVelocity         = native.getVelocity().ToHandedVector3();
       LinearVelocityDamping  = native.getLinearVelocityDamping().ToHandedVector3();

--- a/AGXUnity/Wire.cs
+++ b/AGXUnity/Wire.cs
@@ -238,6 +238,9 @@ namespace AGXUnity
       Radius                  = System.Convert.ToSingle( native.getRadius() );
       ResolutionPerUnitLength = System.Convert.ToSingle( native.getResolutionPerUnitLength() );
       ScaleConstant           = System.Convert.ToSingle( native.getParameterController().getScaleConstant() );
+
+      // Is the wire enabled/active?
+      gameObject.SetActive(native.isEnabled());
     }
 
     protected override bool Initialize()

--- a/Editor/AGXUnityEditor/IO/InputAGXFile.cs
+++ b/Editor/AGXUnityEditor/IO/InputAGXFile.cs
@@ -204,10 +204,12 @@ namespace AGXUnityEditor.IO
           node.GameObject        = GetOrCreateGameObject( node );
           node.GameObject.name   = FindName( nativeRb.getName(), node.Type.ToString() );
 
+
           node.GameObject.transform.position = nativeRb.getPosition().ToHandedVector3();
           node.GameObject.transform.rotation = nativeRb.getRotation().ToHandedQuaternion();
 
           node.GameObject.GetOrCreateComponent<RigidBody>().RestoreLocalDataFrom( nativeRb );
+          
 
           break;
         case Node.NodeType.Geometry:
@@ -429,6 +431,12 @@ namespace AGXUnityEditor.IO
       }
 
       var shape = node.GameObject.GetComponent<AGXUnity.Collide.Shape>();
+
+      // Is the geometry enabled?
+      shape.gameObject.SetActive(nativeGeometry.isEnabled());
+
+    
+
       if ( nativeGeometry.getMaterial() != null ) {
         var shapeMaterial = m_tree.GetNode( nativeGeometry.getMaterial().getUuid() ).Asset as ShapeMaterial;
         if ( shapeMaterial == null )
@@ -580,6 +588,12 @@ namespace AGXUnityEditor.IO
       }
 
       Constraint constraint = node.GameObject.GetOrCreateComponent<Constraint>();
+
+      // Is the constraint enabled/active? 
+      // Somewhat strange though: Why is not only the Constraint component disabled?
+      // For RigidBody component, only that component is disabled, but the below code disables the whole constraint GameObject.
+      // Works for now
+      constraint.gameObject.SetActive(nativeConstraint.isEnabled());
 
       constraint.SetType( constraintType, true );
 


### PR DESCRIPTION
Make sure disabled objects from the read .agx file is disabled also in Unity tree,