### PR TITLE
Fixed error when void was returned instead of Quaternion.

### DIFF
--- a/AGXUnity/IFrame.cs
+++ b/AGXUnity/IFrame.cs
@@ -204,7 +204,7 @@ namespace AGXUnity
       if ( gameObject == null )
         return worldRotation;
 
-      return ( Quaternion.Inverse( gameObject.transform.rotation ) * worldRotation ).Normalize();
+      return ( Quaternion.Inverse( gameObject.transform.rotation ) * worldRotation ).normalized;
     }
 
     public static Quaternion CalculateWorldRotation( GameObject gameObject, Quaternion localRotation )
@@ -212,7 +212,7 @@ namespace AGXUnity
       if ( gameObject == null )
         return localRotation;
 
-      return ( gameObject.transform.rotation * localRotation ).Normalize();
+      return ( gameObject.transform.rotation * localRotation ).normalized;
     }
   }
 }

--- a/AGXUnity/Utils/ShapeInitializationData.cs
+++ b/AGXUnity/Utils/ShapeInitializationData.cs
@@ -78,7 +78,7 @@ namespace AGXUnity.Utils
     public void SetPositionRotation( GameObject gameObject, Vector3 axis )
     {
       gameObject.transform.position = WorldCenter;
-      gameObject.transform.rotation = Rotation * Quaternion.FromToRotation( Vector3.up, axis ).Normalize();
+      gameObject.transform.rotation = Rotation * Quaternion.FromToRotation( Vector3.up, axis ).normalized;
     }
 
     public AxisData FindAxisData( Axes axis, bool expandRadius )

--- a/Editor/AGXUnityEditor/Tools/ShapeCreateTool.cs
+++ b/Editor/AGXUnityEditor/Tools/ShapeCreateTool.cs
@@ -290,7 +290,7 @@ namespace AGXUnityEditor.Tools
       else {
         vp.Node.transform.localScale = Vector3.one;
         vp.Node.transform.position   = shapeInitData.WorldCenter;
-        vp.Node.transform.rotation   = shapeInitData.Rotation * Quaternion.FromToRotation( Vector3.up, axisData.Direction ).Normalize();
+        vp.Node.transform.rotation   = shapeInitData.Rotation * Quaternion.FromToRotation( Vector3.up, axisData.Direction ).normalized;
       }
 
       if ( vp is Utils.VisualPrimitiveBox )


### PR DESCRIPTION
.Normalized() returns a void, changed with .normalized to fix issue. Tested with Unity and works.