### PR TITLE
Solver settings added

### DIFF
--- a/AGXUnity/IO/RestoredAGXFile.cs
+++ b/AGXUnity/IO/RestoredAGXFile.cs
@@ -53,5 +53,15 @@ namespace AGXUnity.IO
 
       m_disabledGroups.Add( new GroupPair() { First = group1, Second = group2 } );
     }
+
+    [SerializeField]
+    private SolverSettings m_solverSettings = null;
+
+    [HideInInspector]
+    public SolverSettings SolverSettings
+    {
+      get { return m_solverSettings; }
+      set { m_solverSettings = value; }
+    }
   }
 }

--- a/AGXUnity/Simulation.cs
+++ b/AGXUnity/Simulation.cs
@@ -65,91 +65,6 @@ namespace AGXUnity
     [SerializeField]
     private float m_timeStep = 1.0f / 50.0f;
 
-
-    /// <summary>
-    /// Specifies whether the warmstarting algorithm should be used for warm starting of contacts
-    /// using the direct solver
-    /// </summary>
-    [SerializeField]
-    private bool m_warmStartingDirectContacts = false;
-
-
-
-    /// <summary>
-    /// Specifies whether the warmstarting algorithm should be used for warm starting of contacts
-    /// using the direct solver
-    /// </summary>
-    public bool WarmStartingDirectContacts
-    {
-      get { return m_warmStartingDirectContacts; }
-      set
-      {
-        m_warmStartingDirectContacts = value;
-        if (m_system != null)
-          m_system.setEnableContactWarmstarting(m_warmStartingDirectContacts);
-      }
-    }
-
-    /// <summary>
-    /// Specifies number of iterations for resting iterations for the iterative solver
-    /// default is -1 indicating it will be initialized from the default in the Dynamics Engine
-    /// </summary>
-    [SerializeField]
-    private int m_numRestingIterations = -1;
-
-    /// <summary>
-    /// Get or set the number of iterations for resting contacts
-    /// </summary>
-    public int NumRestingIterations
-    {
-      get { return m_numRestingIterations; }
-      set
-      {
-        // A value below zero will indicate use default
-        m_numRestingIterations = value;
-        int numIterations = m_numRestingIterations;
-        if (m_numRestingIterations < 0)
-          numIterations = m_defaultNumRestingIterations;
-
-        if (m_simulation != null)
-          m_simulation.getSolver().setNumRestingIterations((ulong)numIterations);
-      }
-    }
-
-    /// <summary>
-    /// Specifies number of iterations for dry friction for the iterative solver
-    /// default is -1 indicating it will be initialized from the default in the Dynamics Engine
-    /// </summary>
-    [SerializeField]
-    private int m_numDryFrictionIterations = -1;
-
-    [NonSerialized]
-    private int m_defaultNumDryFrictionIterations = 0;
-
-    [NonSerialized]
-    private int m_defaultNumRestingIterations = 0;
-
-
-    /// <summary>
-    /// Get or set the number of iterations for resting contacts
-    /// </summary>
-    public int NumDryFrictionIterations
-    {
-      get { return m_numDryFrictionIterations; }
-      set
-      {
-        m_numDryFrictionIterations = value;
-
-        // A value below zero will indicate use default
-        int numIterations = m_numDryFrictionIterations;
-        if (m_numDryFrictionIterations < 0)
-          numIterations = m_defaultNumDryFrictionIterations;
-
-        if (m_simulation != null)
-          m_simulation.getSolver().setNumDryFrictionIterations((ulong)numIterations);
-      }
-    }
-
     /// <summary>
     /// Get or set time step size. Note that the time step has to
     /// match Unity update frequency.
@@ -162,6 +77,34 @@ namespace AGXUnity
         m_timeStep = value;
         if ( m_simulation != null )
           m_simulation.setTimeStep( m_timeStep );
+      }
+    }
+
+    [SerializeField]
+    private SolverSettings m_solverSettings = null;
+
+    /// <summary>
+    /// Get or set solver settings.
+    /// </summary>
+    [AllowRecursiveEditing]
+    [IgnoreSynchronization]
+    public SolverSettings SolverSettings
+    {
+      get { return m_solverSettings; }
+      set
+      {
+        if ( m_solverSettings != null ) {
+          m_solverSettings.SetSimulation( null );
+          if ( value == null )
+            SolverSettings.AssignDefault( m_simulation );
+        }
+
+        m_solverSettings = value;
+
+        if ( m_solverSettings != null && m_simulation != null ) {
+          m_solverSettings.SetSimulation( m_simulation );
+          m_solverSettings.GetInitialized<SolverSettings>();
+        }
       }
     }
 
@@ -543,8 +486,11 @@ namespace AGXUnity
     protected override void OnDestroy()
     {
       base.OnDestroy();
-      if ( m_simulation != null )
+      if ( m_simulation != null ) {
+        if ( m_solverSettings != null )
+          m_solverSettings.SetSimulation( null );
         m_simulation.cleanup();
+      }
       m_simulation = null;
     }
 
@@ -554,14 +500,17 @@ namespace AGXUnity
         NativeHandler.Instance.MakeMainThread();
 
         m_simulation = new agxSDK.Simulation();
-
-        m_defaultNumDryFrictionIterations = (int)m_simulation.getSolver().getNumDryFrictionIterations();
-        m_defaultNumRestingIterations = (int)m_simulation.getSolver().getNumRestingIterations();
-
         m_space = m_simulation.getSpace();
         m_system = m_simulation.getDynamicsSystem();
 
-        m_system.setEnableContactWarmstarting(m_warmStartingDirectContacts);
+        // Solver settings will assign number of threads.
+        if ( m_solverSettings != null ) {
+          m_solverSettings.SetSimulation( m_simulation );
+          m_solverSettings.GetInitialized<SolverSettings>();
+        }
+        // No solver settings - set the default.
+        else
+          agx.agxSWIG.setNumThreads( Convert.ToUInt32( SolverSettings.DefaultNumberOfThreads ) );
       }
 
       return m_simulation;

--- a/AGXUnity/Simulation.cs
+++ b/AGXUnity/Simulation.cs
@@ -182,7 +182,10 @@ namespace AGXUnity
         m_displayStatistics = value;
 
         if ( m_displayStatistics && m_statisticsWindowData == null )
-          m_statisticsWindowData = new StatisticsWindowData( new Rect( new Vector2( 10, 10 ), new Vector2( 275, 320 ) ) );
+          m_statisticsWindowData = new StatisticsWindowData( new Rect( new Vector2( 10, 10 ),
+                                                                       new Vector2( 275, 236 ) ),
+                                                             new Rect( new Vector2( 10, 10 ),
+                                                                       new Vector2( 275, 320 ) ) );
         else if ( !m_displayStatistics && m_statisticsWindowData != null ) {
           m_statisticsWindowData.Dispose();
           m_statisticsWindowData = null;
@@ -192,7 +195,6 @@ namespace AGXUnity
 
     [SerializeField]
     bool m_memorySnapEnabled = false;
-
 
     /// <summary>
     /// Enable/disable statistics window showing timing and simulation data.
@@ -298,19 +300,19 @@ namespace AGXUnity
         if ( DisplayStatistics )
           timer = new agx.Timer( true );
 
-        if (m_memorySnapEnabled)
+        if ( m_memorySnapEnabled )
           MemoryAllocations.Snap( MemoryAllocations.Section.Begin );
 
         if ( StepCallbacks.PreStepForward != null )
           StepCallbacks.PreStepForward.Invoke();
 
-        if (m_memorySnapEnabled)
+        if ( m_memorySnapEnabled )
           MemoryAllocations.Snap( MemoryAllocations.Section.PreStepForward );
 
         if ( StepCallbacks.PreSynchronizeTransforms != null )
           StepCallbacks.PreSynchronizeTransforms.Invoke();
 
-        if (m_memorySnapEnabled)
+        if ( m_memorySnapEnabled )
           MemoryAllocations.Snap( MemoryAllocations.Section.PreSynchronizeTransforms );
 
         if ( timer != null )
@@ -321,19 +323,19 @@ namespace AGXUnity
         if ( timer != null )
           timer.start();
 
-        if (m_memorySnapEnabled)
+        if ( m_memorySnapEnabled )
           MemoryAllocations.Snap( MemoryAllocations.Section.StepForward );
 
         if ( StepCallbacks.PostSynchronizeTransforms != null )
           StepCallbacks.PostSynchronizeTransforms.Invoke();
 
-        if (m_memorySnapEnabled)
+        if ( m_memorySnapEnabled )
           MemoryAllocations.Snap( MemoryAllocations.Section.PostSynchronizeTransforms );
 
         if ( StepCallbacks.PostStepForward != null )
           StepCallbacks.PostStepForward.Invoke();
 
-        if (m_memorySnapEnabled)
+        if ( m_memorySnapEnabled )
           MemoryAllocations.Snap( MemoryAllocations.Section.PostStepForward );
 
         Rendering.DebugRenderManager.OnActiveSimulationPostStep( m_simulation );
@@ -401,15 +403,17 @@ namespace AGXUnity
     {
       public int Id { get; private set; }
       public Rect Rect { get; set; }
+      public Rect RectMemoryEnabled { get; set; }
       public Font Font { get; private set; }
       public GUIStyle LabelStyle { get; set; }
       public float ManagedStepForward { get; set; }
 
-      public StatisticsWindowData( Rect rect )
+      public StatisticsWindowData( Rect rect, Rect rectMemoryEnabled )
       {
         agx.Statistics.instance().setEnable( true );
         Id = GUIUtility.GetControlID( FocusType.Passive );
         Rect = rect;
+        RectMemoryEnabled = rectMemoryEnabled;
 
         MemoryAllocations.Instance = new MemoryAllocations();
         ManagedStepForward = 0.0f;
@@ -491,7 +495,7 @@ namespace AGXUnity
                            m_space.getGeometryContacts().Count;
 
       GUILayout.Window( m_statisticsWindowData.Id,
-                        m_statisticsWindowData.Rect,
+                        MemorySnapEnabled ? m_statisticsWindowData.RectMemoryEnabled : m_statisticsWindowData.Rect,
                         id =>
                         {
                           GUILayout.Label( Utils.GUI.MakeLabel( Utils.GUI.AddColorTag( "Total time:            ", simColor ) + simTime.current.ToString( "0.00" ).PadLeft( 5, ' ' ) + " ms", 14, true ), labelStyle );
@@ -509,6 +513,8 @@ namespace AGXUnity
                           GUILayout.Label( "" );
                           GUILayout.Label( Utils.GUI.MakeLabel( Utils.GUI.AddColorTag( "StepForward (managed):", memoryColor ), 14, true ), labelStyle );
                           GUILayout.Label( Utils.GUI.MakeLabel( Utils.GUI.AddColorTag( "  - Step forward:          ", memoryColor ) + m_statisticsWindowData.ManagedStepForward.ToString( "0.00" ).PadLeft( 5, ' ' ) + " ms" ), labelStyle );
+                          if ( !MemorySnapEnabled )
+                            return;
                           GUILayout.Label( Utils.GUI.MakeLabel( Utils.GUI.AddColorTag( "Allocations (managed):", memoryColor ), 14, true ), labelStyle );
                           GUILayout.Label( Utils.GUI.MakeLabel( Utils.GUI.AddColorTag( "  - Pre step callbacks:    ", memoryColor ) + MemoryAllocations.GetDeltaString( MemoryAllocations.Section.PreStepForward ).PadLeft( 6, ' ' ) ), labelStyle );
                           GUILayout.Label( Utils.GUI.MakeLabel( Utils.GUI.AddColorTag( "  - Pre synchronize:       ", memoryColor ) + MemoryAllocations.GetDeltaString( MemoryAllocations.Section.PreSynchronizeTransforms ).PadLeft( 6, ' ' ) ), labelStyle );

--- a/AGXUnity/SolverSettings.cs
+++ b/AGXUnity/SolverSettings.cs
@@ -251,6 +251,24 @@ namespace AGXUnity
       SimulationInstance = simulation;
     }
 
+    public SolverSettings RestoreLocalDataFrom( agxSDK.Simulation simulation )
+    {
+      var solver = simulation.getSolver();
+      var config = solver.getNlMcpConfig();
+
+      NumberOfThreads         = System.Convert.ToInt32( agx.agxSWIG.getNumThreads() );
+      WarmStartDirectContacts = simulation.getDynamicsSystem().getUpdateTask().getSubtask( "MatchContactStates" ).isEnabled();
+      RestingIterations       = System.Convert.ToInt32( solver.getNumRestingIterations() );
+      DryFrictionIterations   = System.Convert.ToInt32( solver.getNumDryFrictionIterations() );
+      McpAlgorithm            = Convert( config.mcpAlgorithmType );
+      McpInnerIterations      = System.Convert.ToInt32( config.numMcpIterations );
+      McpInnerTolerance       = System.Convert.ToSingle( config.mcpTolerance );
+      McpOuterIterations      = System.Convert.ToInt32( config.numOuterIterations );
+      McpOuterTolerance       = System.Convert.ToSingle( config.outerTolerance );
+
+      return this;
+    }
+
     public override void Destroy()
     {
       SimulationInstance = null;

--- a/AGXUnity/SolverSettings.cs
+++ b/AGXUnity/SolverSettings.cs
@@ -1,0 +1,269 @@
+﻿using System;
+using System.ComponentModel;
+
+using UnityEngine;
+
+namespace AGXUnity
+{
+  public class SolverSettings : ScriptAsset
+  {
+    /// <summary>
+    /// Default number of AGX threads. Assuming processor count includes
+    /// hyper threading, default value is number of physical cores minus one
+    /// but not more than four.
+    /// </summary>
+    [HideInInspector]
+    public static int DefaultNumberOfThreads { get { return Math.Min( SystemInfo.processorCount / 2 - 1, 4 ); } }
+
+    /// <summary>
+    /// Simulation instance is set when this asset is active.
+    /// </summary>
+    [HideInInspector]
+    public agxSDK.Simulation SimulationInstance { get; private set; }
+
+    [SerializeField]
+    private int m_numberOfThreads = 1;
+
+    /// <summary>
+    /// Maximum number of threads used by AGX.
+    /// </summary>
+    /// <remarks>
+    /// It's not recommended to assign values larger than the number of physical cores on
+    /// the target computer.
+    /// </remarks>
+    [Description( "Maximum number of threads used by AGX." )]
+    public int NumberOfThreads
+    {
+      get { return m_numberOfThreads; }
+      set
+      {
+        m_numberOfThreads = Math.Max( value, 1 );
+        if ( SimulationInstance != null )
+          agx.agxSWIG.setNumThreads( System.Convert.ToUInt32( m_numberOfThreads ) );
+      }
+    }
+
+    [SerializeField]
+    private bool m_warmStartDirectContacts = false;
+
+    /// <summary>
+    /// True to warm start frictional contacts in the direct solver. Setting this
+    /// to true could improve solver performance in relatively stationary scenes.
+    /// </summary>
+    [Description( "True to warm start frictional contacts in the direct solver. Default: false" )]
+    public bool WarmStartDirectContacts
+    {
+      get { return m_warmStartDirectContacts; }
+      set
+      {
+        m_warmStartDirectContacts = value;
+        if ( SimulationInstance != null )
+          SimulationInstance.getDynamicsSystem().setEnableContactWarmstarting( m_warmStartDirectContacts );
+      }
+    }
+
+    [SerializeField]
+    private int m_restingIterations = 16;
+
+    /// <summary>
+    /// Number iterations in the iterative solver. Note that the iterative solver
+    /// is used in synergy with the direct solver, so changing this value will
+    /// affect default contact/friction model.
+    /// </summary>
+    [Description( "Number of iteration in the iterative solver. Default: 16" )]
+    public int RestingIterations
+    {
+      get { return m_restingIterations; }
+      set
+      {
+        m_restingIterations = Math.Max( value, 0 );
+        if ( SimulationInstance != null )
+          SimulationInstance.getSolver().setNumRestingIterations( System.Convert.ToUInt64( m_restingIterations ) );
+      }
+    }
+
+    [SerializeField]
+    private int m_dryFrictionIterations = 7;
+
+    /// <summary>
+    /// Number of dry friction iterations used on solve islands where all constraints
+    /// are DIRECT_AND_ITERATIVE and all contact friction models are SPLIT.
+    /// </summary>
+    [Description( "Number of dry friction iterations used on solve islands where " +
+                  "all constraints are DIRECT_AND_ITERATIVE and all contacts SPLIT. Default: 7" )]
+    public int DryFrictionIterations
+    {
+      get { return m_dryFrictionIterations; }
+      set
+      {
+        m_dryFrictionIterations = Math.Max( value, 0 );
+        if ( SimulationInstance != null )
+          SimulationInstance.getSolver().setNumDryFrictionIterations( System.Convert.ToUInt64( m_dryFrictionIterations ) );
+      }
+    }
+
+    public enum McpAlgorithmType
+    {
+      BlockPivot,
+      Keller,
+      HybridPivot
+    }
+
+    /// <summary>
+    /// Convert MCP algorithm type from native to this.
+    /// </summary>
+    /// <param name="type">Native MCP algorithm type.</param>
+    /// <returns>Managed MCP algorithm type.</returns>
+    public static McpAlgorithmType Convert( agx.Solver.McpAlgoritmType type )
+    {
+      return type == agx.Solver.McpAlgoritmType.BLOCK_PIVOT ? McpAlgorithmType.BlockPivot :
+             type == agx.Solver.McpAlgoritmType.KELLER ?      McpAlgorithmType.Keller :
+                                                              McpAlgorithmType.HybridPivot;
+    }
+
+    /// <summary>
+    /// Convert MCP algorithm type from this to native.
+    /// </summary>
+    /// <param name="type">MCP algorithm type.</param>
+    /// <returns>Native MCP algorithm type.</returns>
+    public static agx.Solver.McpAlgoritmType Convert( McpAlgorithmType type )
+    {
+      return type == McpAlgorithmType.BlockPivot ? agx.Solver.McpAlgoritmType.BLOCK_PIVOT :
+             type == McpAlgorithmType.Keller     ? agx.Solver.McpAlgoritmType.KELLER :
+                                                   agx.Solver.McpAlgoritmType.HYBRID_PIVOT;
+    }
+
+    [SerializeField]
+    private McpAlgorithmType m_mcpAlgorithm = McpAlgorithmType.HybridPivot;
+
+    /// <summary>
+    /// MCP solver algorithm type. Block Pivot is fast but can fail. Keller is still
+    /// fast but might never fail. Hybrid Pivot (default) tries to solver the system
+    /// using Block Pivot but use Keller when Block Pivot fails.
+    /// </summary>
+    [Description( "MCP solver algorithm type. Block Pivot is fast but can fail. " +
+                  "Keller is still fast but might never fail. Hybrid Pivot (default) " +
+                  "solves failing Block Pivot using Keller. Default: Hybrid Pivot" )]
+    public McpAlgorithmType McpAlgorithm
+    {
+      get { return m_mcpAlgorithm; }
+      set
+      {
+        m_mcpAlgorithm = value;
+        if ( SimulationInstance != null )
+          SimulationInstance.getSolver().setMcpAlgorithmType( Convert( m_mcpAlgorithm ) );
+      }
+    }
+
+    [SerializeField]
+    private int m_mcpInnerIterations = 7;
+
+    /// <summary>
+    /// Maximum number of MCP iterations used during direct linear solves. Default: 7
+    /// </summary>
+    [Description( "Maximum number of MCP iterations used during direct linear solves. Default: 7" )]
+    public int McpInnerIterations
+    {
+      get { return m_mcpInnerIterations; }
+      set
+      {
+        m_mcpInnerIterations = Math.Max( value, 0 );
+        if ( SimulationInstance != null )
+          SimulationInstance.getSolver().getNlMcpConfig().numMcpIterations = System.Convert.ToUInt64( m_mcpInnerIterations );
+      }
+    }
+
+    [SerializeField]
+    private float m_mcpInnerTolerance = 1.0E-6f;
+
+    /// <summary>
+    /// MCP solver tolerance during linear solves. Default: 1.0E-6
+    /// </summary>
+    [Description( "MCP solver tolerance during linear solves. Default: 1.0E-6" )]
+    public float McpInnerTolerance
+    {
+      get { return m_mcpInnerTolerance; }
+      set
+      {
+        m_mcpInnerTolerance = Mathf.Max( value, 0.0f );
+        if ( SimulationInstance != null )
+          SimulationInstance.getSolver().getNlMcpConfig().mcpTolerance = m_mcpInnerTolerance;
+      }
+    }
+
+    [SerializeField]
+    private int m_mcpOuterIterations = 5;
+
+    /// <summary>
+    /// Maximum number of non-linear (outer) iterations if the direct solver. Default: 5
+    /// </summary>
+    [Description( "Maximum number of non-linear (outer) iterations if the direct solver. Default: 5" )]
+    public int McpOuterIterations
+    {
+      get { return m_mcpOuterIterations; }
+      set
+      {
+        m_mcpOuterIterations = value;
+        if ( SimulationInstance != null )
+          SimulationInstance.getSolver().getNlMcpConfig().numOuterIterations = System.Convert.ToUInt64( m_mcpOuterIterations );
+      }
+    }
+
+    [SerializeField]
+    private float m_mcpOuterTolerance = 1.0E-2f;
+
+    /// <summary>
+    /// Tolerance of non-linear (outer) direct solves. Default: 1.0E-2
+    /// </summary>
+    [Description( "Tolerance of non-linear (outer) direct solves. Default: 1.0E-2" )]
+    public float McpOuterTolerance
+    {
+      get { return m_mcpOuterTolerance; }
+      set
+      {
+        m_mcpOuterTolerance = Mathf.Max( value, 0.0f );
+        if ( SimulationInstance != null )
+          SimulationInstance.getSolver().getNlMcpConfig().outerTolerance = m_mcpOuterTolerance;
+      }
+    }
+
+    /// <summary>
+    /// Assignes default values to a native simulation instace.
+    /// </summary>
+    /// <param name="simulation">Native simulation instance.</param>
+    public static void AssignDefault( agxSDK.Simulation simulation )
+    {
+      if ( simulation == null )
+        return;
+
+      var tmp = Create<SolverSettings>();
+      tmp.SetSimulation( simulation );
+      Utils.PropertySynchronizer.Synchronize( tmp );
+      tmp.SetSimulation( null );
+      ScriptAsset.Destroy( tmp );
+    }
+
+    /// <summary>
+    /// Internal.
+    /// </summary>
+    public void SetSimulation( agxSDK.Simulation simulation )
+    {
+      SimulationInstance = simulation;
+    }
+
+    public override void Destroy()
+    {
+      SimulationInstance = null;
+    }
+
+    protected override void Construct()
+    {
+      NumberOfThreads = DefaultNumberOfThreads;
+    }
+
+    protected override bool Initialize()
+    {
+      return true;
+    }
+  }
+}

--- a/AGXUnity/SolverSettings.cs.meta
+++ b/AGXUnity/SolverSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfe7795c8c53d804492c3defd1af786a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
+++ b/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
@@ -60,6 +60,8 @@ namespace AGXUnityEditor
         renderData.transform.hideFlags |= HideFlags.NotEditable;
       }
 
+      // TODO: Handle fileData.SolverSettings?
+
       Undo.CollapseUndoOperations( grouId );
     }
 

--- a/Editor/AGXUnityEditor/IO/AGXFileInfo.cs
+++ b/Editor/AGXUnityEditor/IO/AGXFileInfo.cs
@@ -163,7 +163,11 @@ namespace AGXUnityEditor.IO
     public AGXFileInfo( GameObject prefabInstance )
     {
       PrefabInstance = prefabInstance;
+#if UNITY_2018_1_OR_NEWER
+      Construct( AssetDatabase.GetAssetPath( PrefabUtility.GetCorrespondingObjectFromSource( prefabInstance ) as GameObject ) );
+#else
       Construct( AssetDatabase.GetAssetPath( PrefabUtility.GetPrefabParent( prefabInstance ) as GameObject ) );
+#endif
     }
 
     /// <summary>

--- a/Editor/AGXUnityEditor/IO/InputAGXFile.cs
+++ b/Editor/AGXUnityEditor/IO/InputAGXFile.cs
@@ -107,6 +107,10 @@ namespace AGXUnityEditor.IO
 
         fileData.DataDirectoryId = FileInfo.DataDirectoryId;
 
+        fileData.SolverSettings = ScriptAsset.Create<SolverSettings>().RestoreLocalDataFrom( Simulation );
+        fileData.SolverSettings.name = FindName( "SolverSettings_" + FileInfo.Name, "SolverSettings" );
+        fileData.SolverSettings = AddOrReplaceAsset( fileData.SolverSettings, AGXUnity.IO.AssetType.Unknown );
+
         foreach ( var root in m_tree.Roots ) {
           subProgress.Tick( root.Name == string.Empty ? root.Type.ToString() : root.Name );
           Generate( root );
@@ -239,7 +243,7 @@ namespace AGXUnityEditor.IO
           node.Asset         = ScriptAsset.Create<ShapeMaterial>().RestoreLocalDataFrom( nativeMaterial );
           node.Asset.name    = FindName( nativeMaterial.getName(), node.Type.ToString() );
 
-          node.Asset = AddOrReplaceAsset( node.Asset as ShapeMaterial, node, AGXUnity.IO.AssetType.ShapeMaterial );
+          node.Asset = AddOrReplaceAsset( node.Asset as ShapeMaterial, AGXUnity.IO.AssetType.ShapeMaterial );
 
           break;
         case Node.NodeType.ContactMaterial:
@@ -268,10 +272,10 @@ namespace AGXUnityEditor.IO
           if ( nativeFrictionModel != null ) {
             var frictionModelAsset        = ScriptAsset.Create<FrictionModel>().RestoreLocalDataFrom( nativeFrictionModel );
             frictionModelAsset.name       = "FrictionModel_" + contactMaterial.name;
-            contactMaterial.FrictionModel = AddOrReplaceAsset( frictionModelAsset, node, AGXUnity.IO.AssetType.FrictionModel );
+            contactMaterial.FrictionModel = AddOrReplaceAsset( frictionModelAsset,  AGXUnity.IO.AssetType.FrictionModel );
           }
 
-          node.Asset = contactMaterial = AddOrReplaceAsset( contactMaterial, node, AGXUnity.IO.AssetType.ContactMaterial );
+          node.Asset = contactMaterial = AddOrReplaceAsset( contactMaterial, AGXUnity.IO.AssetType.ContactMaterial );
 
           break;
         case Node.NodeType.Constraint:
@@ -339,7 +343,7 @@ namespace AGXUnityEditor.IO
       return node.GameObject;
     }
 
-    private T AddOrReplaceAsset<T>( T asset, Node node, AGXUnity.IO.AssetType type )
+    private T AddOrReplaceAsset<T>( T asset, AGXUnity.IO.AssetType type )
       where T : UnityEngine.Object
     {
       var existingAsset = AssetDatabase.LoadAssetAtPath<T>( FileInfo.GetAssetPath( asset ) );
@@ -394,7 +398,7 @@ namespace AGXUnityEditor.IO
           var subMeshes      = splitter.Meshes;
           for ( int i = 0; i < subMeshes.Length; ++i ) {
             subMeshes[ i ].name = "Mesh_" + mesh.name + ( i == 0 ? "" : "_Sub_" + i.ToString() );
-            mesh.AddSourceObject( AddOrReplaceAsset( subMeshes[ i ], node, AGXUnity.IO.AssetType.CollisionMesh ) );
+            mesh.AddSourceObject( AddOrReplaceAsset( subMeshes[ i ], AGXUnity.IO.AssetType.CollisionMesh ) );
           }
         }
         else {
@@ -420,7 +424,7 @@ namespace AGXUnityEditor.IO
           source.RecalculateNormals();
           source.RecalculateTangents();
 
-          source = AddOrReplaceAsset( source, node, AGXUnity.IO.AssetType.CollisionMesh );
+          source = AddOrReplaceAsset( source, AGXUnity.IO.AssetType.CollisionMesh );
 
           mesh.SetSourceObject( source );
         }
@@ -547,9 +551,9 @@ namespace AGXUnityEditor.IO
       if ( renderMaterial.getTransparency() > 0.0f )
         material.SetBlendMode( BlendMode.Transparent );
 
-      material = AddOrReplaceAsset( material, node, AGXUnity.IO.AssetType.Material );
+      material = AddOrReplaceAsset( material, AGXUnity.IO.AssetType.Material );
       foreach ( var mesh in meshes )
-        AddOrReplaceAsset( mesh, node, AGXUnity.IO.AssetType.RenderMesh );
+        AddOrReplaceAsset( mesh, AGXUnity.IO.AssetType.RenderMesh );
 
       var shapeVisual = ShapeVisual.Find( shape );
       if ( shapeVisual != null ) {
@@ -773,7 +777,7 @@ namespace AGXUnityEditor.IO
       var properties = CableProperties.Create<CableProperties>().RestoreLocalDataFrom( nativeCable.getCableProperties(),
                                                                                        nativeCable.getCablePlasticity() );
       properties.name  = cable.name + "_properties";
-      cable.Properties = properties = AddOrReplaceAsset( properties, node, AGXUnity.IO.AssetType.CableProperties );
+      cable.Properties = properties = AddOrReplaceAsset( properties, AGXUnity.IO.AssetType.CableProperties );
 
       for ( var it = nativeCable.getSegments().begin(); !it.EqualWith( nativeCable.getSegments().end() ); it.inc() ) {
         var segment = it.get();

--- a/Editor/AGXUnityEditor/IO/Utils.cs
+++ b/Editor/AGXUnityEditor/IO/Utils.cs
@@ -7,7 +7,7 @@ using UnityEditor;
 
 namespace AGXUnityEditor.IO
 {
-  public static class Utils
+  public static partial class Utils
   {
     private const string m_refDirectory = "AGXUnity";
     private const string m_refScript = "RigidBody.cs";

--- a/Editor/AGXUnityEditor/IO/Yaml.cs
+++ b/Editor/AGXUnityEditor/IO/Yaml.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using UnityEngine;
+
+namespace AGXUnityEditor.IO
+{
+  public static partial class Utils
+  {
+    public class YamlScope
+    {
+      public string Name = string.Empty;
+      public List<string> Lines = new List<string>();
+
+      public bool Parse( StreamReader input )
+      {
+        Name = string.Empty;
+        Lines.Clear();
+
+        var line = string.Empty;
+        while ( ( line = input.ReadLine() ) != null && ( line.Length == 0 || line[ 0 ] == '%' || line.StartsWith( "--- !" ) ) )
+          ;
+
+        if ( line == null )
+          return false;
+
+        Name = line.Substring( 0, line.LastIndexOf( ':' ) );
+        while ( ( line = input.ReadLine() ) != null && !line.StartsWith( "--- !" ) )
+          Lines.Add( line );
+
+        return true;
+      }
+
+      public bool IsScript( string guid )
+      {
+        foreach ( var line in Lines ) {
+          if ( !line.StartsWith( "  m_Script:" ) )
+            continue;
+
+          var guidMatcher = DllToScriptResolver.GuidMatcher.Match( line );
+          return guidMatcher.Success && guidMatcher.Value.Contains( "guid: " + guid );
+        }
+
+        return false;
+      }
+    }
+
+    public struct YamlEntry
+    {
+      public string Value;
+
+      public bool TryGet( out bool value )
+      {
+        value = false;
+
+        try {
+          var intVal = Convert.ToInt32( Value );
+          if ( intVal < 0 || intVal > 1 )
+            throw new FormatException();
+          value = intVal == 1;
+          return true;
+        }
+        catch ( Exception ) {
+          return false;
+        }
+      }
+
+      public bool TryGet( out int value )
+      {
+        value = 0;
+
+        try {
+          value = Convert.ToInt32( Value );
+          return true;
+        }
+        catch ( Exception ) {
+          return false;
+        }
+      }
+
+      public bool TryGet( out float value )
+      {
+        value = 0.0f;
+
+        try {
+          value = Convert.ToSingle( Value );
+          return true;
+        }
+        catch ( Exception ) {
+          return false;
+        }
+      }
+
+      public bool TryGet( out double value )
+      {
+        value = 0.0;
+
+        try {
+          value = Convert.ToDouble( Value );
+          return true;
+        }
+        catch ( Exception ) {
+          return false;
+        }
+      }
+
+      public bool TryGet( out Vector3 value )
+      {
+        value = Vector3.zero;
+
+        try {
+          var start = Value.IndexOf( '{' );
+          var end = Value.LastIndexOf( '}' );
+          if ( end <= start )
+            throw new FormatException();
+
+          var strings = Value.Substring( start, end ).Split( ',' );
+          var x = Convert.ToSingle( strings[ 0 ].Split( ':' )[ 1 ].Trim() );
+          var y = Convert.ToSingle( strings[ 1 ].Split( ':' )[ 1 ].Trim() );
+          var z = Convert.ToSingle( strings[ 2 ].Split( ':' )[ 1 ].Trim() );
+
+          value.x = x;
+          value.y = y;
+          value.z = z;
+
+          return true;
+        }
+        catch ( Exception ) {
+          return false;
+        }
+      }
+
+      public bool TryGet( out Quaternion value )
+      {
+        value = Quaternion.identity;
+
+        try {
+          var start = Value.IndexOf( '{' );
+          var end = Value.LastIndexOf( '}' );
+          if ( end <= start )
+            throw new FormatException();
+
+          var strings = Value.Substring( start, end ).Split( ',' );
+          var x = Convert.ToSingle( strings[ 0 ].Split( ':' )[ 1 ].Trim() );
+          var y = Convert.ToSingle( strings[ 1 ].Split( ':' )[ 1 ].Trim() );
+          var z = Convert.ToSingle( strings[ 2 ].Split( ':' )[ 1 ].Trim() );
+          var w = Convert.ToSingle( strings[ 3 ].Split( ':' )[ 1 ].Trim() );
+
+          value.x = x;
+          value.y = y;
+          value.z = z;
+          value.w = w;
+
+          return true;
+        }
+        catch ( Exception ) {
+          return false;
+        }
+      }
+    }
+
+    public class YamlObject
+    {
+      public Dictionary<string, YamlEntry> Fields = new Dictionary<string, YamlEntry>();
+
+      public YamlObject( YamlScope scope )
+      {
+        foreach ( var line in scope.Lines ) {
+          var delimiter = line.IndexOf( ':' );
+          if ( delimiter < 0 )
+            continue;
+          var isEmpty = delimiter == line.Length;
+          Fields.Add( line.Substring( 0, delimiter ).Trim(),
+                      new YamlEntry()
+                      {
+                        Value = isEmpty ?
+                                  string.Empty :
+                                  line.Substring( delimiter + 1, line.Length - delimiter - 1 ).Trim()
+                      } );
+        }
+      }
+    }
+
+    public static YamlObject[] FindScriptInSceneFile( string sceneFile, string guid, bool searchMultiple = true )
+    {
+      List<YamlObject> objects = new List<YamlObject>();
+      try {
+        var file = new FileInfo( sceneFile );
+        var scope = new YamlScope();
+        using ( var input = file.OpenText() ) {
+          while ( scope.Parse( input ) ) {
+            if ( scope.IsScript( guid ) ) {
+              objects.Add( new YamlObject( scope ) );
+              if ( !searchMultiple )
+                break;
+            }
+          }
+        }
+      }
+      catch ( Exception e ) {
+        Debug.LogException( e );
+      }
+
+      return objects.ToArray();
+    }
+  }
+}

--- a/Editor/AGXUnityEditor/IO/Yaml.cs.meta
+++ b/Editor/AGXUnityEditor/IO/Yaml.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62a0d576ce33411478640f71c754e5b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AGXUnityEditor/Menus/AssetsMenu.cs
+++ b/Editor/AGXUnityEditor/Menus/AssetsMenu.cs
@@ -49,6 +49,11 @@ namespace AGXUnityEditor
       return Selection.activeObject = Utils.AssetFactory.Create<TwoBodyTireProperties>("two body tire properties");
     }
 
+    [MenuItem( "Assets/AGXUnity/Solver Settings" )]
+    public static UnityEngine.Object CrateSolverSettings()
+    {
+      return Selection.activeObject = Utils.AssetFactory.Create<SolverSettings>( "solver settings" );
+    }
 
     [MenuItem( "Assets/Import AGX file as prefab", validate = true )]
     public static bool IsAGXFileSelected()

--- a/Editor/AGXUnityEditor/Tools/SimulationTool.cs
+++ b/Editor/AGXUnityEditor/Tools/SimulationTool.cs
@@ -31,6 +31,15 @@ namespace AGXUnityEditor.Tools
     public override void OnPostTargetMembersGUI( GUISkin skin )
     {
       GUI.Separator();
+
+      Simulation.DisplayStatistics = GUI.Toggle( GUI.MakeLabel( "Display Statistics" ), Simulation.DisplayStatistics, skin.button, skin.label );
+      if ( Simulation.DisplayStatistics ) {
+        using ( new GUI.Indent( 12 ) )
+          Simulation.DisplayMemoryAllocations = GUI.Toggle( GUI.MakeLabel( "Display Memory Allocations" ), Simulation.DisplayMemoryAllocations, skin.button, skin.label );
+      }
+
+      GUI.Separator();
+
       using ( new GUILayout.HorizontalScope() ) {
         EditorGUI.BeginDisabledGroup( !Application.isPlaying );
         if ( GUILayout.Button( GUI.MakeLabel( "Save current step as (.agx)...",
@@ -53,6 +62,7 @@ namespace AGXUnityEditor.Tools
       }
 
       GUI.Separator();
+
       Simulation.SavePreFirstStep = GUI.Toggle( GUI.MakeLabel( "Dump initial (.agx):" ),
                                                                 Simulation.SavePreFirstStep,
                                                                 skin.button,


### PR DESCRIPTION
Added solver settings asset that can be assigned to a simulation instance. Removed all solver settings related values from Simulation. When a scene is loaded, any modified solver setting (old version) will be moved to file and assigned to the existing simulation instance.

Fixed deprecated-warnings from Unity.

Renamed `m_memorySnapEnabled` to `m_displayMemoryAllocations` and only showing this option when `DisplayStatistics` is enabled.