### PR TITLE
Object pools

### DIFF
--- a/AGXUnity/Collide/Shape.cs
+++ b/AGXUnity/Collide/Shape.cs
@@ -373,11 +373,11 @@ namespace AGXUnity.Collide
       bool isInstanced = Rendering.DebugRenderManager.IsActiveForSynchronize;
       bool enabled = false;
 
-      if (isInstanced)
+      if ( isInstanced )
         enabled = Rendering.DebugRenderManager.Instance.isActiveAndEnabled;
 
       // If we have a body the debug rendering synchronization is made from that body.
-      if (enabled &&  m_geometry != null && m_geometry.getRigidBody() == null )
+      if ( enabled && m_geometry != null && m_geometry.getRigidBody() == null )
         Rendering.DebugRenderManager.OnPostSynchronizeTransforms( this );
     }
 

--- a/AGXUnity/Constraint.cs
+++ b/AGXUnity/Constraint.cs
@@ -414,7 +414,7 @@ namespace AGXUnity
     }
 
     /// <summary>
-    /// Set compliance to one or all rotatinal ordinary degrees of freedom
+    /// Set compliance to one or all rotational ordinary degrees of freedom
     /// (not including controllers) of this constraint.
     /// </summary>
     /// <param name="compliance">New compliance.</param>
@@ -447,7 +447,7 @@ namespace AGXUnity
     }
 
     /// <summary>
-    /// Set damping to one or all rotatinal ordinary degrees of freedom
+    /// Set damping to one or all rotational ordinary degrees of freedom
     /// (not including controllers) of this constraint.
     /// </summary>
     /// <param name="damping">New damping.</param>
@@ -480,7 +480,7 @@ namespace AGXUnity
     }
 
     /// <summary>
-    /// Set force range to one or all rotatinal ordinary degrees of freedom
+    /// Set force range to one or all rotational ordinary degrees of freedom
     /// (not including controllers) of this constraint.
     /// </summary>
     /// <param name="forceRange">New force range.</param>

--- a/AGXUnity/Rendering/CableRenderer.cs
+++ b/AGXUnity/Rendering/CableRenderer.cs
@@ -84,9 +84,6 @@ namespace AGXUnity.Rendering
         var points = Cable.GetRoutePoints();
         for ( int i = 1; i < points.Length; ++i )
           m_segmentSpawner.CreateSegment( points[ i - 1 ], points[ i ], radius );
-        //CableRouteNode[] nodes = route.ToArray();
-        //for ( int i = 1; i < nodes.Length; ++i )
-        //  m_segmentSpawner.CreateSegment( nodes[ i - 1 ].Position, nodes[ i ].Position, radius );
       }
       catch ( System.Exception e ) {
         Debug.LogException( e, this );
@@ -108,10 +105,11 @@ namespace AGXUnity.Rendering
         return;
       }
 
+      agxCable.CableIterator it = native.begin();
+      agxCable.CableIterator endIt = native.end();
+
       m_segmentSpawner.Begin();
       try {
-        agxCable.CableIterator it = native.begin();
-        agxCable.CableIterator endIt = native.end();
         float radius = Cable.Radius;
         while ( !it.EqualWith( endIt ) ) {
           m_segmentSpawner.CreateSegment( it.getBeginPosition().ToHandedVector3(), it.getEndPosition().ToHandedVector3(), radius );
@@ -122,6 +120,9 @@ namespace AGXUnity.Rendering
         Debug.LogException( e, this );
       }
       m_segmentSpawner.End();
+
+      it.ReturnToPool();
+      endIt.ReturnToPool();
     }
   }
 }

--- a/AGXUnity/Rendering/WireRenderer.cs
+++ b/AGXUnity/Rendering/WireRenderer.cs
@@ -110,46 +110,39 @@ namespace AGXUnity.Rendering
         return;
       }
 
-      if (m_positions == null)
-      {
+      if ( m_positions == null ) {
         m_positions = new List<Vector3>();
         m_positions.Capacity = 256;
       }
 
-      //UnityEngine.Profiling.Profiler.BeginSample("CollectingWirePoints");
       m_positions.Clear();
 
       agxWire.RenderIterator it = wire.Native.getRenderBeginIterator();
       agxWire.RenderIterator endIt = wire.Native.getRenderEndIterator();
-      while (!it.EqualWith(endIt))
-      {
-        m_positions.Add(it.getWorldPosition().ToHandedVector3());
+      while ( !it.EqualWith( endIt ) ) {
+        m_positions.Add( it.getWorldPosition().ToHandedVector3() );
         it.inc();
       }
-      //UnityEngine.Profiling.Profiler.EndSample();
+
       m_segmentSpawner.Begin();
 
       try
       {
-        //UnityEngine.Profiling.Profiler.BeginSample("GeneratingSegments");
-        for (int i = 0; i < m_positions.Count - 1; ++i)
-        {
-          Vector3 curr = m_positions[i];
-          Vector3 next = m_positions[i + 1];
-          Vector3 currToNext = next - curr;
-          float distance = currToNext.magnitude;
-          currToNext /= distance;
-          int numSegments = Convert.ToInt32(distance * NumberOfSegmentsPerMeter + 0.5f);
-          float dl = distance / numSegments;
-          for (int j = 0; j < numSegments; ++j)
-          {
+        for ( int i = 0; i < m_positions.Count - 1; ++i ) {
+          Vector3 curr        = m_positions[i];
+          Vector3 next        = m_positions[i + 1];
+          Vector3 currToNext  = next - curr;
+          float distance      = currToNext.magnitude;
+          currToNext         /= distance;
+          int numSegments     = Convert.ToInt32(distance * NumberOfSegmentsPerMeter + 0.5f);
+          float dl            = distance / numSegments;
+          for ( int j = 0; j < numSegments; ++j ) {
             next = curr + dl * currToNext;
 
             m_segmentSpawner.CreateSegment(curr, next, wire.Radius);
             curr = next;
           }
         }
-        //UnityEngine.Profiling.Profiler.EndSample();
       }
       catch (System.Exception e)
       {
@@ -157,6 +150,9 @@ namespace AGXUnity.Rendering
       }
 
       m_segmentSpawner.End();
+
+      it.ReturnToPool();
+      endIt.ReturnToPool();
     }
   }
 }

--- a/Editor/AGXUnityEditor/Manager.cs
+++ b/Editor/AGXUnityEditor/Manager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -58,7 +57,7 @@ namespace AGXUnityEditor
       // will probably be loaded again after the fix.
       if ( !VerifyCompatibility() )
         return;
-
+      
       SceneView.onSceneGUIDelegate += OnSceneView;
 #if UNITY_2018_1_OR_NEWER
       EditorApplication.hierarchyChanged += OnHierarchyWindowChanged;


### PR DESCRIPTION
Avoids creating garbage rendering wires, cables and contact points.

Requires AGX Dynamics 2.24.1.0 or later.
Requires .NET runtime version 4.x (experimental/equivalent).