### PR TITLE
Prefab workflow and Wire/Cable runtime objects

### DIFF
--- a/AGXUnity/Cable.cs
+++ b/AGXUnity/Cable.cs
@@ -6,7 +6,6 @@ using AGXUnity.Utils;
 namespace AGXUnity
 {
   [AddComponentMenu( "" )]
-  [RequireComponent( typeof( Rendering.CableRenderer ) )]
   [RequireComponent( typeof( CableRoute ) )]
   public class Cable : ScriptComponent
   {

--- a/AGXUnity/IO/RestoredAGXFile.cs
+++ b/AGXUnity/IO/RestoredAGXFile.cs
@@ -63,5 +63,13 @@ namespace AGXUnity.IO
       get { return m_solverSettings; }
       set { m_solverSettings = value; }
     }
+
+    protected override bool Initialize()
+    {
+      using ( var foo = new AGXUnity.Utils.TimerBlock( "Adding pairs." ) )
+        m_disabledGroups.ForEach( gp => CollisionGroupsManager.Instance.SetEnablePair( gp.First, gp.Second, false ) );
+
+      return true;
+    }
   }
 }

--- a/AGXUnity/IO/RestoredAGXFile.cs
+++ b/AGXUnity/IO/RestoredAGXFile.cs
@@ -66,8 +66,7 @@ namespace AGXUnity.IO
 
     protected override bool Initialize()
     {
-      using ( var foo = new AGXUnity.Utils.TimerBlock( "Adding pairs." ) )
-        m_disabledGroups.ForEach( gp => CollisionGroupsManager.Instance.SetEnablePair( gp.First, gp.Second, false ) );
+      m_disabledGroups.ForEach( gp => CollisionGroupsManager.Instance.SetEnablePair( gp.First, gp.Second, false ) );
 
       return true;
     }

--- a/AGXUnity/IO/SavedPrefabLocalData.cs
+++ b/AGXUnity/IO/SavedPrefabLocalData.cs
@@ -21,5 +21,12 @@ namespace AGXUnity.IO
 
       m_disabledGroups.Add( new GroupPair() { First = group1, Second = group2 } );
     }
+
+    protected override bool Initialize()
+    {
+      m_disabledGroups.ForEach( gp => CollisionGroupsManager.Instance.SetEnablePair( gp.First, gp.Second, false ) );
+
+      return true;
+    }
   }
 }

--- a/AGXUnity/Rendering/CableRenderer.cs
+++ b/AGXUnity/Rendering/CableRenderer.cs
@@ -5,8 +5,8 @@ using AGXUnity.Utils;
 
 namespace AGXUnity.Rendering
 {
-  [AddComponentMenu( "" )]
   [ExecuteInEditMode]
+  [RequireComponent( typeof( Cable ) )]
   public class CableRenderer : ScriptComponent
   {
     [SerializeField]

--- a/AGXUnity/Rendering/ShapeDebugRenderData.cs
+++ b/AGXUnity/Rendering/ShapeDebugRenderData.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using UnityEngine;
+﻿using UnityEngine;
 using AGXUnity.Collide;
 using AGXUnity.Utils;
 
@@ -110,8 +109,8 @@ namespace AGXUnity.Rendering
         }
 
         // Forcing the debug render node to be parent to the static DebugRenderManger.
-        if ( Node.transform.parent != manager.gameObject.transform )
-          manager.gameObject.AddChild( Node );
+        if ( Node.transform.parent != manager.Root.transform )
+          manager.Root.AddChild( Node );
 
         Node.transform.position = shape.transform.position;
         Node.transform.rotation = shape.transform.rotation;

--- a/AGXUnity/Rendering/WireRenderer.cs
+++ b/AGXUnity/Rendering/WireRenderer.cs
@@ -6,8 +6,8 @@ using AGXUnity.Utils;
 
 namespace AGXUnity.Rendering
 {
-  [AddComponentMenu( "" )]
   [ExecuteInEditMode]
+  [RequireComponent( typeof( Wire ) )]
   public class WireRenderer : ScriptComponent
   {
     [SerializeField]

--- a/AGXUnity/RuntimeObjects.cs
+++ b/AGXUnity/RuntimeObjects.cs
@@ -1,0 +1,132 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace AGXUnity
+{
+  [ExecuteInEditMode]
+  public class RuntimeObjects : UniqueGameObject<RuntimeObjects>
+  {
+    private Dictionary<MonoBehaviour, string> m_potentiallyDeletedParents = new Dictionary<MonoBehaviour, string>();
+
+    public static GameObject GetOrCreateRoot( MonoBehaviour script )
+    {
+      if ( script == null )
+        return null;
+
+      var instance = RecoverAndGetInstance();
+      if ( instance == null )
+        return null;
+
+      var name  = GetName( script );
+      var child = instance.transform.Find( name );
+      if ( child != null )
+        return child.gameObject;
+
+      var go = new GameObject( name );
+
+      go.hideFlags = HideFlags.DontSaveInEditor;
+      go.transform.hideFlags = go.hideFlags | HideFlags.NotEditable;
+
+      go.transform.SetParent( instance.transform );
+
+      return go;
+    }
+
+    public static bool HasRoot( MonoBehaviour script )
+    {
+      var instance = RecoverAndGetInstance();
+      return script != null && instance != null && instance.transform.Find( GetName( script ) );
+    }
+
+    public static void RegisterAsPotentiallyDeleted( MonoBehaviour script )
+    {
+      // If we're destroyed it's likely the script isn't deleted.
+      // The editor is probably going into play.
+      if ( IsDestroyed )
+        return;
+
+      var instance = RecoverAndGetInstance();
+      if ( instance == null )
+        return;
+
+      if ( instance.m_potentiallyDeletedParents.ContainsKey( script ) )
+        return;
+
+      instance.m_potentiallyDeletedParents.Add( script, GetName( script ) );
+    }
+
+    protected override bool Initialize()
+    {
+      gameObject.transform.hideFlags = gameObject.hideFlags | HideFlags.NotEditable;
+
+      return true;
+    }
+
+    protected override void OnDestroy()
+    {
+      base.OnDestroy();
+    }
+
+    private void Update()
+    {
+      gameObject.transform.position = Vector3.zero;
+      gameObject.transform.rotation = Quaternion.identity;
+      // Change parent before scale is set - otherwise scale will be preserved.
+      // E.g., move "this" to a parent with scale x, scale will be set,
+      // parent = null will remove the parent but the scale will be preserved.
+      // Fix - set scale after set parent.
+      gameObject.transform.parent = null;
+      gameObject.transform.localScale = Vector3.one;
+
+      List<GameObject> rootsToRemove = new List<GameObject>();
+      foreach ( Transform rootTransform in transform ) {
+        rootTransform.position   = Vector3.zero;
+        rootTransform.rotation   = Quaternion.identity;
+        rootTransform.localScale = Vector3.one;
+
+        if ( rootTransform.childCount == 0 )
+          continue;
+        var selectionProxy = rootTransform.GetChild( 0 ).GetComponent<Utils.OnSelectionProxy>();
+        if ( selectionProxy == null || selectionProxy.Component == null )
+          rootsToRemove.Add( rootTransform.gameObject );
+      }
+
+      foreach ( var kvp in m_potentiallyDeletedParents ) {
+        if ( kvp.Key != null )
+          continue;
+
+        var rootTransform = transform.Find( kvp.Value );
+        if ( rootTransform == null )
+          continue;
+
+        if ( !rootsToRemove.Contains( rootTransform.gameObject ) )
+          rootsToRemove.Add( rootTransform.gameObject );
+      }
+      m_potentiallyDeletedParents.Clear();
+
+      while ( rootsToRemove.Count > 0 ) {
+        DestroyImmediate( rootsToRemove.Last() );
+        rootsToRemove.RemoveAt( rootsToRemove.Count - 1 );
+      }
+
+      if ( transform.childCount == 0 ) {
+        DestroyImmediate( gameObject );
+        // Reset destroyed state so that another instance may be created.
+        ResetDestroyedState();
+      }
+    }
+
+    private static string GetName( MonoBehaviour script )
+    {
+      return script.name + "_ro_" + script.GetInstanceID().ToString();
+    }
+
+    private static RuntimeObjects RecoverAndGetInstance()
+    {
+      if ( IsDestroyed && HasInstance )
+        ResetDestroyedState();
+      return Instance;
+    }
+  }
+}

--- a/AGXUnity/RuntimeObjects.cs.meta
+++ b/AGXUnity/RuntimeObjects.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b6a9e4af77e3804aae97d5030ab5f9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AGXUnity/UniqueGameObject.cs
+++ b/AGXUnity/UniqueGameObject.cs
@@ -45,6 +45,8 @@ namespace AGXUnity
 
     public static bool HasInstance { get { return m_instance != null || (FindObjectOfType( typeof( T ) ) as T ) != null; } }
 
+    public static bool IsDestroyed { get { return m_destroyed; } }
+
     /// <summary>
     /// Use with care. Reset the internal reset state so this
     /// object may be created again.

--- a/AGXUnity/Wire.cs
+++ b/AGXUnity/Wire.cs
@@ -7,7 +7,6 @@ namespace AGXUnity
   /// Wire object.
   /// </summary>
   [AddComponentMenu( "" )]
-  [RequireComponent( typeof( Rendering.WireRenderer ) )]
   [RequireComponent( typeof( WireRoute ) )]
   public class Wire : ScriptComponent
   {
@@ -315,9 +314,14 @@ namespace AGXUnity
       base.OnDestroy();
     }
 
+    private Rendering.WireRenderer m_renderer = null;
     private void OnPostStepForward()
     {
-      GetComponent<Rendering.WireRenderer>().OnPostStepForward( this );
+      if ( m_renderer == null )
+        m_renderer = GetComponent<Rendering.WireRenderer>();
+
+      if ( m_renderer != null )
+        m_renderer.OnPostStepForward( this );
 
       if ( BeginWinch != null )
         BeginWinch.OnPostStepForward( this );
@@ -325,5 +329,26 @@ namespace AGXUnity
       if ( EndWinch != null )
         EndWinch.OnPostStepForward( this );
     }
+
+    //private void DrawGizmos( Color color )
+    //{
+    //  if ( Application.isPlaying )
+    //    return;
+
+    //  var nodes = Route.ToArray();
+    //  Gizmos.color = color;
+    //  for ( int i = 1; i < nodes.Length; ++i )
+    //    Gizmos.DrawLine( nodes[ i - 1 ].Position, nodes[ i ].Position );
+    //}
+
+    //private void OnDrawGizmos()
+    //{
+    //  DrawGizmos( Color.red );
+    //}
+
+    //private void OnDrawGizmosSelected()
+    //{
+    //  DrawGizmos( Color.green );
+    //}
   }
 }

--- a/AGXUnity/WireRoute.cs
+++ b/AGXUnity/WireRoute.cs
@@ -18,8 +18,8 @@ namespace AGXUnity
   /// var freeNodes = from node in route select node.Type == Wire.NodeType.FreeNode;
   /// Wire.RouteNode myNode = route.FirstOrDefault( node => node.Frame == thisFrame );
   /// </example>
-  [Serializable]
   [HideInInspector]
+  [AddComponentMenu("")]
   public class WireRoute : Route<WireRouteNode>
   {
     /// <summary>

--- a/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
+++ b/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
@@ -63,10 +63,12 @@ namespace AGXUnityEditor
       if ( m_isProcessingPrefabInstance )
         return;
 
+      var isAGXPrefab = instance.GetComponent<AGXUnity.IO.RestoredAGXFile>() != null;
+
       // Collect group ids that are disabled in the CollisionGroupsManager so that
       // when this prefab is added to a scene, the disabled collisions will be
       // added again.
-      if ( CollisionGroupsManager.HasInstance ) {
+      if ( !isAGXPrefab && CollisionGroupsManager.HasInstance ) {
 #if UNITY_2018_1_OR_NEWER
         var prefab = PrefabUtility.GetCorrespondingObjectFromSource( instance ) as GameObject;
 #else

--- a/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
+++ b/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
@@ -89,7 +89,7 @@ namespace AGXUnityEditor
                                 where !CollisionGroupsManager.Instance.GetEnablePair( tag1.Tag, tag2.Tag )
                                 select new AGXUnity.IO.GroupPair() { First = tag1.Tag, Second = tag2.Tag };
             if ( disabledPairs.Count() > 0 ) {
-#if UNITY_2018_1_OR_NEWER
+#if UNITY_2017_3_OR_NEWER
 #if UNITY_2018_3_OR_NEWER
               var savedData = instance.GetComponent<AGXUnity.IO.SavedPrefabLocalData>();
               if ( savedData == null ) {

--- a/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
+++ b/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
@@ -89,16 +89,27 @@ namespace AGXUnityEditor
                                 where !CollisionGroupsManager.Instance.GetEnablePair( tag1.Tag, tag2.Tag )
                                 select new AGXUnity.IO.GroupPair() { First = tag1.Tag, Second = tag2.Tag };
             if ( disabledPairs.Count() > 0 ) {
+#if UNITY_2018_1_OR_NEWER
+#if UNITY_2018_3_OR_NEWER
               var savedData = instance.GetComponent<AGXUnity.IO.SavedPrefabLocalData>();
               if ( savedData == null ) {
                 savedData = instance.AddComponent<AGXUnity.IO.SavedPrefabLocalData>();
                 PrefabUtility.ApplyAddedComponent( savedData, AssetDatabase.GetAssetPath( prefab ), InteractionMode.AutomatedAction );
               }
-
+#else
+              var savedData = prefab.GetComponent<AGXUnity.IO.SavedPrefabLocalData>();
+              if ( savedData == null )
+                savedData = prefab.AddComponent<AGXUnity.IO.SavedPrefabLocalData>();
+#endif
+#endif
               foreach ( var disabledPair in disabledPairs )
                 savedData.AddDisabledPair( disabledPair.First, disabledPair.Second );
 
+#if UNITY_2018_3_OR_NEWER
               PrefabUtility.ApplyPrefabInstance( instance, InteractionMode.AutomatedAction );
+#else
+              EditorUtility.SetDirty( prefab );
+#endif
             }
           }
           finally {

--- a/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
+++ b/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
@@ -36,6 +36,11 @@ namespace AGXUnityEditor
 
     public static void OnPrefabAddedToScene( GameObject instance )
     {
+      if ( AutoUpdateSceneHandler.VerifyPrefabInstance( instance ) ) {
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+      }
+
       var fileInfo = new IO.AGXFileInfo( instance );
       if ( !fileInfo.IsValid || fileInfo.Type != IO.AGXFileInfo.FileType.AGXPrefab )
         return;
@@ -43,11 +48,6 @@ namespace AGXUnityEditor
       if ( fileInfo.ExistingPrefab == null ) {
         Debug.LogWarning( "Unable to load parent prefab from file: " + fileInfo.NameWithExtension );
         return;
-      }
-
-      if ( AutoUpdateSceneHandler.VerifyPrefabInstance( instance ) ) {
-        AssetDatabase.SaveAssets();
-        AssetDatabase.Refresh();
       }
 
       Undo.SetCurrentGroupName( "Adding: " + instance.name + " to scene." );

--- a/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
+++ b/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
@@ -45,6 +45,11 @@ namespace AGXUnityEditor
         return;
       }
 
+      if ( AutoUpdateSceneHandler.VerifyPrefabInstance( instance ) ) {
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+      }
+
       Undo.SetCurrentGroupName( "Adding: " + instance.name + " to scene." );
       var grouId = Undo.GetCurrentGroup();
 
@@ -52,7 +57,8 @@ namespace AGXUnityEditor
         TopMenu.GetOrCreateUniqueGameObject<ContactMaterialManager>().Add( cm );
 
       var fileData = fileInfo.ExistingPrefab.GetComponent<AGXUnity.IO.RestoredAGXFile>();
-      AddDisabledPairsToManager( fileData.DisabledGroups );
+      foreach ( var disabledPair in fileData.DisabledGroups )
+        TopMenu.GetOrCreateUniqueGameObject<CollisionGroupsManager>().SetEnablePair( disabledPair.First, disabledPair.Second, false );
 
       var renderDatas = instance.GetComponentsInChildren<AGXUnity.Rendering.ShapeVisual>();
       foreach ( var renderData in renderDatas ) {
@@ -63,12 +69,6 @@ namespace AGXUnityEditor
       // TODO: Handle fileData.SolverSettings?
 
       Undo.CollapseUndoOperations( grouId );
-    }
-
-    private static void AddDisabledPairsToManager( AGXUnity.IO.GroupPair[] disabledPairs )
-    {
-      foreach ( var disabledPair in disabledPairs )
-        TopMenu.GetOrCreateUniqueGameObject<CollisionGroupsManager>().SetEnablePair( disabledPair.First, disabledPair.Second, false );
     }
   }
 }

--- a/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
+++ b/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs
@@ -6,18 +6,18 @@ namespace AGXUnityEditor
 {
   public class AssetPostprocessorHandler : AssetPostprocessor
   {
-    public static UnityEngine.Object ReadAGXFile( string path )
+    public static Object ReadAGXFile( string path )
     {
       return ReadAGXFile( new IO.AGXFileInfo( path ) );
     }
 
-    public static UnityEngine.Object ReadAGXFile( IO.AGXFileInfo info )
+    public static Object ReadAGXFile( IO.AGXFileInfo info )
     {
       if ( info == null || !info.IsValid )
         return null;
 
       try {
-        UnityEngine.Object prefab = null;
+        Object prefab = null;
         using ( var inputFile = new IO.InputAGXFile( info ) ) {
           inputFile.TryLoad();
           inputFile.TryParse();
@@ -34,6 +34,63 @@ namespace AGXUnityEditor
       return null;
     }
 
+    private static void OnPrefabUpdate( GameObject go )
+    {
+#if UNITY_2018_3_OR_NEWER
+      // Can't remember why we do this and we're not allowed to add
+      // components to a prefab.
+      Debug.Log( "Update: " + go.name + ", instance status: " + PrefabUtility.GetPrefabInstanceStatus( go ) + ", prefab status: " + PrefabUtility.GetPrefabAssetType( go ) );
+      Debug.Log( "Instance id: " + go.GetInstanceID() + ", source id: " + PrefabUtility.GetCorrespondingObjectFromSource<GameObject>( go ).GetInstanceID() );
+#else
+      // Collecting disabled collision groups for the created prefab.
+      if ( AGXUnity.CollisionGroupsManager.HasInstance ) {
+#if UNITY_2018_1_OR_NEWER
+        var prefab = PrefabUtility.GetCorrespondingObjectFromSource( go ) as GameObject;
+#else
+        var prefab = PrefabUtility.GetPrefabParent( go ) as GameObject;
+#endif
+        if ( prefab != null ) {
+          var allGroups = prefab.GetComponentsInChildren<AGXUnity.CollisionGroups>();
+          var tags = ( from objectGroups
+                       in allGroups
+                       from tag
+                       in objectGroups.Groups
+                       select tag ).Distinct( new CollisionGroupEntryEqualityComparer() ).ToList();
+          var disabledPairs = new List<AGXUnity.IO.GroupPair>();
+          foreach ( var t1 in tags )
+            foreach ( var t2 in tags )
+              if ( !AGXUnity.CollisionGroupsManager.Instance.GetEnablePair( t1.Tag, t2.Tag ) )
+                disabledPairs.Add( new AGXUnity.IO.GroupPair() { First = t1.Tag, Second = t2.Tag } );
+
+          if ( disabledPairs.Count > 0 ) {
+            var prefabLocalData = prefab.GetOrCreateComponent<AGXUnity.IO.SavedPrefabLocalData>();
+            foreach ( var groupPair in disabledPairs )
+              prefabLocalData.AddDisabledPair( groupPair.First, groupPair.Second );
+            EditorUtility.SetDirty( prefabLocalData );
+          }
+        }
+      }
+#endif
+    }
+
+    /// <summary>
+    /// Callback when a prefab is created from a scene game object <paramref name="go"/>,
+    /// i.e., drag-dropped from hierarchy to the assets folder.
+    /// </summary>
+    /// <param name="instance">Prefab instance.</param>
+    public static void OnPrefabCreatedFromScene( GameObject instance )
+    {
+      // Collect group ids that are disabled in the CollisionGroupsManager so that
+      // when this prefab is added to a scene, the disabled collisions will be
+      // added again.
+      if ( CollisionGroupsManager.HasInstance ) {
+      }
+    }
+
+    /// <summary>
+    /// Callback when a prefab (likely) has been drag-dropped into a scene.
+    /// </summary>
+    /// <param name="instance">Prefab instance.</param>
     public static void OnPrefabAddedToScene( GameObject instance )
     {
       if ( AutoUpdateSceneHandler.VerifyPrefabInstance( instance ) ) {
@@ -41,10 +98,15 @@ namespace AGXUnityEditor
         AssetDatabase.Refresh();
       }
 
-      var fileInfo = new IO.AGXFileInfo( instance );
-      if ( !fileInfo.IsValid || fileInfo.Type != IO.AGXFileInfo.FileType.AGXPrefab )
-        return;
+      OnSavedPrefabAddedToScene( instance, instance.GetComponent<AGXUnity.IO.SavedPrefabLocalData>() );
 
+      var fileInfo = new IO.AGXFileInfo( instance );
+      if ( fileInfo.IsValid && fileInfo.Type == IO.AGXFileInfo.FileType.AGXPrefab )
+        OnAGXPrefabAdddedToScene( instance, fileInfo );
+    }
+
+    private static void OnAGXPrefabAdddedToScene( GameObject instance, IO.AGXFileInfo fileInfo )
+    {
       if ( fileInfo.ExistingPrefab == null ) {
         Debug.LogWarning( "Unable to load parent prefab from file: " + fileInfo.NameWithExtension );
         return;
@@ -68,6 +130,18 @@ namespace AGXUnityEditor
 
       // TODO: Handle fileData.SolverSettings?
 
+      Undo.CollapseUndoOperations( grouId );
+    }
+
+    private static void OnSavedPrefabAddedToScene( GameObject instance, AGXUnity.IO.SavedPrefabLocalData savedPrefabData )
+    {
+      if ( savedPrefabData == null || savedPrefabData.DisabledGroups.Length == 0 )
+        return;
+
+      Undo.SetCurrentGroupName( "Adding prefab data for " + instance.name + " to scene." );
+      var grouId = Undo.GetCurrentGroup();
+      foreach ( var disabledGroup in savedPrefabData.DisabledGroups )
+        TopMenu.GetOrCreateUniqueGameObject<CollisionGroupsManager>().SetEnablePair( disabledGroup.First, disabledGroup.Second, false );
       Undo.CollapseUndoOperations( grouId );
     }
   }

--- a/Editor/AGXUnityEditor/AutoUpdateSceneHandler.cs
+++ b/Editor/AGXUnityEditor/AutoUpdateSceneHandler.cs
@@ -58,7 +58,11 @@ namespace AGXUnityEditor
                                                      InteractionMode.UserAction );
 #else
           PrefabUtility.ReplacePrefab( objectToCheck,
+#if UNITY_2018_1_OR_NEWER
                                        (GameObject)PrefabUtility.GetCorrespondingObjectFromSource( instance ),
+#else
+                                       PrefabUtility.GetPrefabParent( instance ),
+#endif
                                        ReplacePrefabOptions.ConnectToPrefab );
 #endif
         }

--- a/Editor/AGXUnityEditor/IO/AGXFileInfo.cs
+++ b/Editor/AGXUnityEditor/IO/AGXFileInfo.cs
@@ -170,6 +170,11 @@ namespace AGXUnityEditor.IO
 #endif
     }
 
+    public void SetPrefabInstance( GameObject instance )
+    {
+      PrefabInstance = instance;
+    }
+
     /// <summary>
     /// Creates an instance from an existing project prefab or creates
     /// a new game object. Accessible trough this.PrefabInstance.
@@ -290,11 +295,15 @@ namespace AGXUnityEditor.IO
         return null;
       }
 
+#if UNITY_2018_3_OR_NEWER
+      return PrefabUtility.SaveAsPrefabAssetAndConnect( PrefabInstance, PrefabPath, InteractionMode.UserAction );
+#else
       var prefab = ExistingPrefab ?? PrefabUtility.CreateEmptyPrefab( PrefabPath );
       if ( prefab == null )
         return null;
 
       return PrefabUtility.ReplacePrefab( PrefabInstance, prefab, ReplacePrefabOptions.ReplaceNameBased );
+#endif
     }
 
     /// <summary>

--- a/Editor/AGXUnityEditor/IO/InputAGXFile.cs
+++ b/Editor/AGXUnityEditor/IO/InputAGXFile.cs
@@ -671,6 +671,8 @@ namespace AGXUnityEditor.IO
 
       route.Clear();
 
+      node.GameObject.GetOrCreateComponent<WireRenderer>();
+
       wire.RestoreLocalDataFrom( nativeWire );
 
       var nativeIt         = nativeWire.getRenderBeginIterator();
@@ -754,6 +756,8 @@ namespace AGXUnityEditor.IO
       var route = cable.Route;
 
       route.Clear();
+
+      node.GameObject.GetOrCreateComponent<CableRenderer>();
 
       cable.RestoreLocalDataFrom( nativeCable );
       cable.RouteAlgorithm = Cable.RouteType.Identity;

--- a/Editor/AGXUnityEditor/IO/Yaml.cs
+++ b/Editor/AGXUnityEditor/IO/Yaml.cs
@@ -185,6 +185,9 @@ namespace AGXUnityEditor.IO
 
     public static YamlObject[] FindScriptInSceneFile( string sceneFile, string guid, bool searchMultiple = true )
     {
+      if ( sceneFile == string.Empty )
+        return new YamlObject[] { };
+
       List<YamlObject> objects = new List<YamlObject>();
       try {
         var file = new FileInfo( sceneFile );

--- a/Editor/AGXUnityEditor/Manager.cs
+++ b/Editor/AGXUnityEditor/Manager.cs
@@ -84,7 +84,7 @@ namespace AGXUnityEditor
 
       CreateDefaultAssets();
 
-      PrefabUtility.prefabInstanceUpdated += OnPrefabUpdate;
+      PrefabUtility.prefabInstanceUpdated += AssetPostprocessorHandler.OnPrefabCreatedFromScene;
     }
 
     /// <summary>
@@ -388,17 +388,14 @@ namespace AGXUnityEditor
         AutoUpdateSceneHandler.HandleUpdates( scene );
       }
       else if ( Selection.activeGameObject != null ) {
-        if ( Selection.activeGameObject.GetComponent<AGXUnity.IO.RestoredAGXFile>() != null )
+#if UNITY_2018_3_OR_NEWER
+        var isPrefabInstance = PrefabUtility.GetPrefabInstanceStatus( Selection.activeGameObject ) != PrefabInstanceStatus.NotAPrefab;
+#else
+        var isPrefabInstance = PrefabUtility.GetPrefabType( Selection.activeGameObject ) == PrefabType.PrefabInstance ||
+                               PrefabUtility.GetPrefabType( Selection.activeGameObject ) == PrefabType.DisconnectedPrefabInstance;
+#endif
+        if ( isPrefabInstance )
           AssetPostprocessorHandler.OnPrefabAddedToScene( Selection.activeGameObject );
-
-        var savedPrefabData = Selection.activeGameObject.GetComponent<AGXUnity.IO.SavedPrefabLocalData>();
-        if ( savedPrefabData != null && savedPrefabData.DisabledGroups.Length > 0 ) {
-          Undo.SetCurrentGroupName( "Adding prefab data for " + Selection.activeGameObject.name + " to scene." );
-          var grouId = Undo.GetCurrentGroup();
-          foreach ( var disabledGroup in savedPrefabData.DisabledGroups )
-            TopMenu.GetOrCreateUniqueGameObject<AGXUnity.CollisionGroupsManager>().SetEnablePair( disabledGroup.First, disabledGroup.Second, false );
-          Undo.CollapseUndoOperations( grouId );
-        }
       }
 
       m_numScenesLoaded = EditorSceneManager.loadedSceneCount;
@@ -576,46 +573,6 @@ namespace AGXUnityEditor
       {
         return entry.Tag.GetHashCode();
       }
-    }
-
-    /// <summary>
-    /// Callback when a prefab is created from a gameobject <paramref name="go"/>.
-    /// </summary>
-    private static void OnPrefabUpdate( GameObject go )
-    {
-#if UNITY_2018_3_OR_NEWER
-      // Can't remember why we do this and we're not allowed to add
-      // components to a prefab.
-#else
-      // Collecting disabled collision groups for the created prefab.
-      if ( AGXUnity.CollisionGroupsManager.HasInstance ) {
-#if UNITY_2018_1_OR_NEWER
-        var prefab = PrefabUtility.GetCorrespondingObjectFromSource( go ) as GameObject;
-#else
-        var prefab = PrefabUtility.GetPrefabParent( go ) as GameObject;
-#endif
-        if ( prefab != null ) {
-          var allGroups = prefab.GetComponentsInChildren<AGXUnity.CollisionGroups>();
-          var tags = ( from objectGroups
-                       in allGroups
-                       from tag
-                       in objectGroups.Groups
-                       select tag ).Distinct( new CollisionGroupEntryEqualityComparer() ).ToList();
-          var disabledPairs = new List<AGXUnity.IO.GroupPair>();
-          foreach ( var t1 in tags )
-            foreach ( var t2 in tags )
-              if ( !AGXUnity.CollisionGroupsManager.Instance.GetEnablePair( t1.Tag, t2.Tag ) )
-                disabledPairs.Add( new AGXUnity.IO.GroupPair() { First = t1.Tag, Second = t2.Tag } );
-
-          if ( disabledPairs.Count > 0 ) {
-            var prefabLocalData = prefab.GetOrCreateComponent<AGXUnity.IO.SavedPrefabLocalData>();
-            foreach ( var groupPair in disabledPairs )
-              prefabLocalData.AddDisabledPair( groupPair.First, groupPair.Second );
-            EditorUtility.SetDirty( prefabLocalData );
-          }
-        }
-      }
-#endif
     }
   }
 }

--- a/Editor/AGXUnityEditor/Manager.cs
+++ b/Editor/AGXUnityEditor/Manager.cs
@@ -241,6 +241,7 @@ namespace AGXUnityEditor
     }
 
     private static string m_currentSceneName = string.Empty;
+    private static int m_numScenesLoaded = 0;
     private static bool m_requestSceneViewFocus = false;
     private static HijackLeftMouseClickData m_hijackLeftMouseClickData = null;
 
@@ -375,7 +376,11 @@ namespace AGXUnityEditor
     private static void OnHierarchyWindowChanged()
     {
       var scene = EditorSceneManager.GetActiveScene();
-      if ( scene.name != m_currentSceneName || EditorSceneManager.sceneCount > EditorSceneManager.previewSceneCount ) {
+      var isSceneLoaded = scene.name != m_currentSceneName ||
+                          // Drag drop of scene into hierarchy.
+                          EditorSceneManager.loadedSceneCount > m_numScenesLoaded;
+
+      if ( isSceneLoaded ) {
         EditorData.Instance.GC();
 
         m_currentSceneName = scene.name;
@@ -395,6 +400,8 @@ namespace AGXUnityEditor
           Undo.CollapseUndoOperations( grouId );
         }
       }
+
+      m_numScenesLoaded = EditorSceneManager.loadedSceneCount;
     }
 
     /// <summary>

--- a/Editor/AGXUnityEditor/Manager.cs
+++ b/Editor/AGXUnityEditor/Manager.cs
@@ -561,18 +561,5 @@ namespace AGXUnityEditor
       GetOrCreateAsset<AGXUnity.GeometryContactMergeSplitThresholds>( IO.Utils.AGXUnityResourceDirectory + '/' + AGXUnity.GeometryContactMergeSplitThresholds.ResourcePath + ".asset" );
       GetOrCreateAsset<AGXUnity.ConstraintMergeSplitThresholds>( IO.Utils.AGXUnityResourceDirectory + '/' + AGXUnity.ConstraintMergeSplitThresholds.ResourcePath + ".asset" );
     }
-
-    private class CollisionGroupEntryEqualityComparer : IEqualityComparer<AGXUnity.CollisionGroupEntry>
-    {
-      public bool Equals( AGXUnity.CollisionGroupEntry cg1, AGXUnity.CollisionGroupEntry cg2 )
-      {
-        return cg1.Tag == cg2.Tag;
-      }
-
-      public int GetHashCode( AGXUnity.CollisionGroupEntry entry )
-      {
-        return entry.Tag.GetHashCode();
-      }
-    }
   }
 }

--- a/Editor/AGXUnityEditor/Manager.cs
+++ b/Editor/AGXUnityEditor/Manager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEditor;
+using UnityEditor.SceneManagement;
 using AGXUnity.Utils;
 
 namespace AGXUnityEditor
@@ -373,8 +374,8 @@ namespace AGXUnityEditor
 
     private static void OnHierarchyWindowChanged()
     {
-      var scene = UnityEditor.SceneManagement.EditorSceneManager.GetActiveScene();
-      if ( scene.name != m_currentSceneName ) {
+      var scene = EditorSceneManager.GetActiveScene();
+      if ( scene.name != m_currentSceneName || EditorSceneManager.sceneCount > EditorSceneManager.previewSceneCount ) {
         EditorData.Instance.GC();
 
         m_currentSceneName = scene.name;
@@ -575,6 +576,10 @@ namespace AGXUnityEditor
     /// </summary>
     private static void OnPrefabUpdate( GameObject go )
     {
+#if UNITY_2018_3_OR_NEWER
+      // Can't remember why we do this and we're not allowed to add
+      // components to a prefab.
+#else
       // Collecting disabled collision groups for the created prefab.
       if ( AGXUnity.CollisionGroupsManager.HasInstance ) {
 #if UNITY_2018_1_OR_NEWER
@@ -603,6 +608,7 @@ namespace AGXUnityEditor
           }
         }
       }
+#endif
     }
   }
 }

--- a/Editor/AGXUnityEditor/Tools/DebugRenderManagerTool.cs
+++ b/Editor/AGXUnityEditor/Tools/DebugRenderManagerTool.cs
@@ -22,7 +22,11 @@ namespace AGXUnityEditor.Tools
 
       GUI.Separator();
 
-      Manager.RenderShapes = GUI.Toggle( GUI.MakeLabel( "Debug render shapes" ), Manager.RenderShapes, skin.button, skin.label );
+      var newRenderState = GUI.Toggle( GUI.MakeLabel( "Debug render shapes" ), Manager.RenderShapes, skin.button, skin.label );
+      if ( newRenderState != Manager.RenderShapes ) {
+        Manager.RenderShapes = newRenderState;
+        EditorUtility.SetDirty( Manager );
+      }
       GUI.MaterialEditor( GUI.MakeLabel( "Shape material" ), 100, Manager.ShapeRenderMaterial, skin, newMaterial => Manager.ShapeRenderMaterial = newMaterial, true );
 
       GUI.Separator();

--- a/Editor/AGXUnityEditor/Utils/DrawGizmoCallbackHandler.cs
+++ b/Editor/AGXUnityEditor/Utils/DrawGizmoCallbackHandler.cs
@@ -39,6 +39,18 @@ namespace AGXUnityEditor.Utils
       } );
     }
 
+    [DrawGizmo( GizmoType.Active | GizmoType.Selected | GizmoType.NotInSelectionHierarchy | GizmoType.Pickable )]
+    public static void OnDrawGizmosWire( Wire wire, GizmoType gizmoType )
+    {
+      if ( wire.Native != null )
+        return;
+
+      var nodes = wire.Route.ToArray();
+      Gizmos.color = (gizmoType & GizmoType.Selected) != 0 ? Color.green : Color.red;
+      for ( int i = 1; i < nodes.Length; ++i )
+        Gizmos.DrawLine( nodes[ i - 1 ].Position, nodes[ i ].Position );
+    }
+
     [DrawGizmo( GizmoType.Active | GizmoType.NotInSelectionHierarchy )]
     public static void OnDrawGizmosDebugRenderManager( DebugRenderManager manager, GizmoType gizmoType )
     {

--- a/Resources/Materials/CableMaterial_01.mat
+++ b/Resources/Materials/CableMaterial_01.mat
@@ -4,13 +4,14 @@
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: CableMaterial_01
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: _EMISSION
   m_LightmapFlags: 1
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Resources/Materials/ConstraintDebugRenderMaterialMaterial.mat
+++ b/Resources/Materials/ConstraintDebugRenderMaterialMaterial.mat
@@ -4,13 +4,14 @@
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: ConstraintDebugRenderMaterialMaterial
   m_Shader: {fileID: 45, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 5
-  m_EnableInstancingVariants: 0
+  m_ShaderKeywords: _EMISSION
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
@@ -63,11 +64,15 @@ Material:
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _GlossMapScale: 1
     - _Glossiness: 0.245
+    - _GlossyReflections: 1
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
     - _ZWrite: 1

--- a/Resources/Materials/DebugRendererMaterial.mat
+++ b/Resources/Materials/DebugRendererMaterial.mat
@@ -4,13 +4,14 @@
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: DebugRendererMaterial
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 5
-  m_EnableInstancingVariants: 0
+  m_ShaderKeywords: _EMISSION
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
@@ -71,13 +72,17 @@ Material:
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _GlossMapScale: 1
     - _Glossiness: 0
+    - _GlossyReflections: 1
     - _InvFade: 1
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _Shininess: 0.25654158
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
     - _ZWrite: 1

--- a/Resources/Materials/ShapeVisualDefaultMaterial.mat
+++ b/Resources/Materials/ShapeVisualDefaultMaterial.mat
@@ -4,13 +4,14 @@
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: ShapeVisualDefaultMaterial
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}

--- a/Resources/Materials/WireMaterial_01.mat
+++ b/Resources/Materials/WireMaterial_01.mat
@@ -4,13 +4,14 @@
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: WireMaterial_01
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: _NORMALMAP
-  m_LightmapFlags: 5
-  m_EnableInstancingVariants: 0
+  m_ShaderKeywords: _EMISSION
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
@@ -59,12 +60,16 @@ Material:
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _GlossMapScale: 1
     - _Glossiness: 0.476
+    - _GlossyReflections: 1
     - _Metallic: 0.343
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _Shininess: 0.078125
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
     - _ZWrite: 1


### PR DESCRIPTION
*  Trying to adopt to Unity 2018.3 prefab workflow update.
*  Removed required `CableRenderer` for `Cable` - renderer is optional from now on.
*  Removed required `WireRenderer` for `Wire` - renderer is optional from now on.
*  Added `AGXUnity.RuntimeObjects` where wire/cable renderers are storing runtime objects, preventing changing prefab instances during runtime.

Tested with Unity 2017.4.10, 2018.2.14 and 2018.3.5.