### PR TITLE
Cache transform in rigidbody and shape

### DIFF
--- a/AGXUnity/Collide/Shape.cs
+++ b/AGXUnity/Collide/Shape.cs
@@ -19,6 +19,11 @@ namespace AGXUnity.Collide
     private ShapeUtils m_utils = null;
 
     /// <summary>
+    /// Cached unity-transform.
+    /// </summary>
+    private Transform m_transform;
+
+    /// <summary>
     /// Native geometry instance.
     /// </summary>
     protected agxCollide.Geometry m_geometry = null;
@@ -274,6 +279,8 @@ namespace AGXUnity.Collide
     /// <returns></returns>
     protected override bool Initialize()
     {
+      m_transform = transform;
+      
       m_shape = CreateNative();
 
       if ( m_shape == null )
@@ -390,7 +397,7 @@ namespace AGXUnity.Collide
     {
       // Automatic synchronization if we have a parent.
       if ( m_geometry != null && m_geometry.getRigidBody() == null )
-        m_geometry.setLocalTransform( new agx.AffineMatrix4x4( transform.rotation.ToHandedQuat(), transform.position.ToHandedVec3() ) );
+        m_geometry.setLocalTransform( new agx.AffineMatrix4x4( m_transform.rotation.ToHandedQuat(), m_transform.position.ToHandedVec3() ) );
     }
 
     /// <summary>
@@ -400,9 +407,8 @@ namespace AGXUnity.Collide
     protected virtual void SyncUnityTransform()
     {
       if ( transform.parent == null && m_geometry != null ) {
-        agx.AffineMatrix4x4 t = m_geometry.getTransform();
-        transform.position = t.getTranslate().ToHandedVector3();
-        transform.rotation = t.getRotate().ToHandedQuaternion();
+        m_transform.SetPositionAndRotation(m_geometry.getPosition().ToHandedVector3(),
+          m_geometry.getRotation().ToHandedQuaternion());
       }
     }
   }

--- a/AGXUnity/RigidBody.cs
+++ b/AGXUnity/RigidBody.cs
@@ -23,6 +23,11 @@ namespace AGXUnity
     /// Cached mass properties component.
     /// </summary>
     private MassProperties m_massPropertiesComponent = null;
+    
+    /// <summary>
+    /// Cached unity-transform.
+    /// </summary>
+    private Transform m_transform;
 
     #region Public Serialized Properties
     /// <summary>
@@ -302,6 +307,8 @@ namespace AGXUnity
     #region Protected Virtual Methods
     protected override bool Initialize()
     {
+      m_transform = transform;
+      
       VerifyConfiguration();
 
       m_rb = new agx.RigidBody();
@@ -383,8 +390,7 @@ namespace AGXUnity
       // Local or global here? If we have a parent that moves?
       // If the parent moves, its transform has to be synced
       // down, and that is hard.
-      transform.position = m_rb.getPosition().ToHandedVector3();
-      transform.rotation = m_rb.getRotation().ToHandedQuaternion();
+      m_transform.SetPositionAndRotation(m_rb.getPosition().ToHandedVector3(), m_rb.getRotation().ToHandedQuaternion()); 
     }
 
     private void SyncProperties()
@@ -402,15 +408,15 @@ namespace AGXUnity
       if ( nativeRb == null )
         return;
 
-      nativeRb.setPosition( transform.position.ToHandedVec3() );
-      nativeRb.setRotation( transform.rotation.ToHandedQuat() );
+      nativeRb.setPosition( m_transform.position.ToHandedVec3() );
+      nativeRb.setRotation( m_transform.rotation.ToHandedQuat() );
     }
 
     private void VerifyConfiguration()
     {
       // Verification:
       // - No parent may be a body.
-      var parent = transform.parent;
+      var parent = m_transform.parent;
       while ( parent != null ) {
         bool hasBody = parent.GetComponent<RigidBody>() != null;
         if ( hasBody )


### PR DESCRIPTION
Adds transform caching to rigidbody and shape. Also, changes the way to apply the position and rotation to use the SetPositionAndRotation method.

I noticed that retrieving the position and rotation over the matrix is really slow in comparison.

My test-results with 2400 rigidbodys for the **PostStepForward** method:

Current: ~4.1 ms
With caching: ~ 3.6 ms
With caching+SetPositionAndRotation: ~ 3.3ms => 20% less
With caching+SetPositionAndRotation+Using matrix: **~5.6ms**

Maybe you can confirm this.