### PR TITLE
Handle absolute CMAKE_INSTALL_PREFIX

### DIFF
--- a/Editor/AGXUnityEditor/ExternalAGXInitializer.cs
+++ b/Editor/AGXUnityEditor/ExternalAGXInitializer.cs
@@ -250,9 +250,16 @@ namespace AGXUnityEditor
 
       binData[ AGX_DEPENDENCIES ].Directory = dependenciesDir.GetDirectories( $"agx_dependencies_{binData[ AGX_DEPENDENCIES ].Value}*" ).FirstOrDefault();
       binData[ AGXTERRAIN_DEPENDENCIES ].Directory = dependenciesDir.GetDirectories( $"agxTerrain_dependencies_{binData[ AGXTERRAIN_DEPENDENCIES ].Value}*" ).FirstOrDefault();
-      binData[ INSTALLED ].Directory = new DirectoryInfo( AGX_DIR +
-                                                          Path.DirectorySeparatorChar +
-                                                          binData[ INSTALLED ].Value );
+
+      // Handle both absolute and relative CMAKE_INSTALL_PREFIX
+      var installPath = binData[INSTALLED].Value;
+      if (Path.IsPathRooted(installPath))
+        binData[ INSTALLED ].Directory = new DirectoryInfo( installPath );
+      else
+        binData[ INSTALLED ].Directory = new DirectoryInfo( AGX_DIR +
+                                                            Path.DirectorySeparatorChar +
+                                                            installPath );
+
       if ( binData.Any( data => data.Directory == null || !data.Directory.Exists ) ) {
         foreach ( var data in binData )
           if ( data.Directory == null || !data.Directory.Exists )


### PR DESCRIPTION
This allows `CMAKE_INSTALL_PREFIX` to be both relative and absolute when using source-built AGX applications. This is required if building out-of-source, since a relative `CMAKE_INSTALL_PREFIX` is interpreted as being relative to the **source** directory by CMake, while `AGX_DIR` in the AGXUnity code is relative to the **binary** directory.