### PR TITLE
Patch release fixes

### DIFF
--- a/AGXUnity/ElementaryConstraintRowData.cs
+++ b/AGXUnity/ElementaryConstraintRowData.cs
@@ -71,7 +71,7 @@ namespace AGXUnity
     /// Damping of this row in the elementary constraint. Paired with property Damping.
     /// </summary>
     [SerializeField]
-    private float m_damping = 2.0f / 60.0f;
+    private float m_damping = 2.0f / 50.0f;
 
     /// <summary>
     /// Damping of this row in the elementary constraint.
@@ -121,7 +121,10 @@ namespace AGXUnity
       m_row = row;
       if ( tmpEc != null ) {
         m_compliance = Convert.ToSingle( tmpEc.getCompliance( RowUInt ) );
-        m_damping = Convert.ToSingle( tmpEc.getDamping( RowUInt ) );
+        // AGX Dynamics damping is optimized for 60 Hz simulations. Assuming
+        // a fixed update of 50 Hz in Unity we scale the damping by 60 / 50 = 1.2
+        // to transform the damping to 50 Hz.
+        m_damping = 1.2f * Convert.ToSingle( tmpEc.getDamping( RowUInt ) );
         m_forceRange = new RangeReal( tmpEc.getForceRange( RowUInt ) );
       }
     }

--- a/AGXUnity/FrictionController.cs
+++ b/AGXUnity/FrictionController.cs
@@ -56,6 +56,25 @@ namespace AGXUnity
       }
     }
 
+    [SerializeField]
+    private RangeReal m_minimumStaticFrictionForceRange = new RangeReal( 0.0f );
+
+    /// <summary>
+    /// Minimum friction force (range) that is always applied, independent
+    /// of the current normal force. This is the "joint.dynamics.friction"
+    /// parameter in the URDF specification. Default: (0, 0)
+    /// </summary>
+    public RangeReal MinimumStaticFrictionForceRange
+    {
+      get { return m_minimumStaticFrictionForceRange; }
+      set
+      {
+        m_minimumStaticFrictionForceRange = value;
+        if ( Native != null )
+          agx.FrictionController.safeCast( Native ).setMinimumStaticFrictionForceRange( m_minimumStaticFrictionForceRange.Native );
+      }
+    }
+
     protected override void Construct( agx.ElementaryConstraint tmpEc )
     {
       base.Construct( tmpEc );

--- a/AGXUnity/IO/URDF/Model.cs
+++ b/AGXUnity/IO/URDF/Model.cs
@@ -314,15 +314,12 @@ namespace AGXUnity.IO.URDF
           linkGo.transform.parent = robot.transform;
           linkInstanceTable.Add( link.Name, linkGo );
 
-          // IsWorld == true when <link name="a_link" />.
-          if ( !link.IsWorld ) {
-            var rb = CreateRigidBody( linkGo, link );
-            foreach ( var collision in link.Collisions )
-              OnElementGameObject( AddCollision( rb, collision ), collision );
+          var rb = CreateRigidBody( linkGo, link );
+          foreach ( var collision in link.Collisions )
+            OnElementGameObject( AddCollision( rb, collision ), collision );
 
-            foreach ( var visual in link.Visuals )
-              OnElementGameObject( AddVisual( rb, visual ), visual );
-          }
+          foreach ( var visual in link.Visuals )
+            OnElementGameObject( AddVisual( rb, visual ), visual );
 
           OnElementGameObject( linkGo, link );
         }
@@ -606,7 +603,7 @@ namespace AGXUnity.IO.URDF
         // CM frame and rotate the game object.
         var rotationMatrix = link.Inertial.Rpy.RadEulerToRotationMatrix();
         var inertia3x3 = (agx.Matrix3x3)link.Inertial.Inertia;
-        inertia3x3 = rotationMatrix.Multiply( inertia3x3 ).Multiply( rotationMatrix.transpose() );
+        inertia3x3 = rotationMatrix.transpose().Multiply( inertia3x3 ).Multiply( rotationMatrix );
         native.getMassProperties().setInertiaTensor( new agx.SPDMatrix3x3( inertia3x3 ) );
         native.getCmFrame().setLocalTranslate( link.Inertial.Xyz.ToVec3() );
 

--- a/AGXUnity/IO/URDF/Model.cs
+++ b/AGXUnity/IO/URDF/Model.cs
@@ -788,6 +788,17 @@ namespace AGXUnity.IO.URDF
             }
           }
         }
+
+        if ( joint.Dynamics.Enabled ) {
+          if ( joint.Dynamics.Friction > 0 ) {
+            var frictionController = constraint.GetController<FrictionController>();
+            if ( frictionController != null ) {
+              frictionController.Enable = true;
+              frictionController.FrictionCoefficient = 0.0f;
+              frictionController.MinimumStaticFrictionForceRange = new RangeReal( joint.Dynamics.Friction );
+            }
+          }
+        }
       }
       else
         constraintGameObject = new GameObject( joint.name );

--- a/AGXUnity/IO/URDF/UJoint.cs
+++ b/AGXUnity/IO/URDF/UJoint.cs
@@ -141,7 +141,7 @@ namespace AGXUnity.IO.URDF
       public float Damping;
 
       /// <summary>
-      /// Friction coefficient of the joint.
+      /// Minimum static friction force in the joint.
       /// </summary>
       public float Friction;
 

--- a/AGXUnity/RigidBodyEmitter.cs
+++ b/AGXUnity/RigidBodyEmitter.cs
@@ -520,6 +520,7 @@ namespace AGXUnity
               visual.transform.SetParent( m_visualRoot.transform );
             visual.transform.position = instance.getPosition().ToHandedVector3();
             visual.transform.rotation = instance.getRotation().ToHandedQuaternion();
+            visual.transform.localScale = resource.transform.lossyScale;
 
             m_instanceDataTable.Add( instance.get(), new EmitData()
             {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can find packages in [Releases](https://github.com/Algoryx/AGXUnity/releases
 
 ### Requirements
 
-+ AGX Dynamics 2.30.2.0 (64-bit) or later (2.29.1.0 in rc/2.3, 2.29.0.0 in rc/2.1, 2.28.1.0 in rc/2.0).
++ AGX Dynamics 2.30.3.0 (64-bit) or later (2.29.1.0 in rc/2.3, 2.29.0.0 in rc/2.1, 2.28.1.0 in rc/2.0).
 + Unity 3D 2018.4 LTS (64-bit) or later. Could work in earlier version but hasn't been tested.
 + Unity Script Runtime Version .NET 4.x Equivalent.
 + Valid AGX Dynamics license. [Contact us for more information.](https://www.algoryx.se/contact/)


### PR DESCRIPTION
### Fixes
- Default damping in constraints (including controllers) is changed from 0.0333 (AGX Dynamics) to 0.04. The new default damping is more suitable for 50 Hz simulations (Unity default) versus 0.0333 for 60 Hz (AGX Dynamics default). ([cae213b](https://github.com/Algoryx/AGXUnity/commit/cae213be830f6e0e49fecf5a2663f733fbc39f98))
- Fixed bug in the URDF reader transforming the inertia to the rigid body frame. ([84af16e](https://github.com/Algoryx/AGXUnity/commit/84af16ee089918cc01cf0403b285f13369d9f1a6))
- Creating an `AGXUnity.RigidBody` for all declared links in an URDF model. Empty links will get a dynamic rigid body with default mass and inertia (1 kg and diagonal inertia [1, 1, 1]). ([84af16e](https://github.com/Algoryx/AGXUnity/commit/84af16ee089918cc01cf0403b285f13369d9f1a6))
- Fixed URDF joint dynamics friction. Requires AGX Dynamics 2.30.3.0 or later. ([75469ac](https://github.com/Algoryx/AGXUnity/commit/75469ac91ad9b54d7647e698f36062f00f1f30fb))
- Propagating lossy scale of the visuals used by the rigid body emitter. ([c23df33](https://github.com/Algoryx/AGXUnity/commit/c23df337d210bc446d1372fc00f4447904d2216f))