### PR TITLE
Patches

### DIFF
--- a/Editor/AGXUnityEditor/IconManager.cs
+++ b/Editor/AGXUnityEditor/IconManager.cs
@@ -327,9 +327,10 @@ namespace AGXUnityEditor
     {
       var disabledScope = new EditorGUI.DisabledScope( !enabled );
       var buttonContent = content.image != null ? ToolButtonTooltip( content ) : content;
-      var pressed = UnityEngine.GUI.Button( rect,
+      var pressed = UnityEngine.GUI.Toggle( rect,
+                                            active,
                                             buttonContent,
-                                            InspectorEditor.Skin.GetButton( active, buttonType ) );
+                                            InspectorEditor.Skin.GetButton( buttonType ) ) != active;
       if ( buttonContent == s_tooltipContent && content.image != null ) {
         using ( IconManager.ForegroundColorBlock( active, enabled ) )
           UnityEngine.GUI.DrawTexture( IconManager.GetIconRect( rect ), content.image );

--- a/Editor/AGXUnityEditor/InspectorGUI.cs
+++ b/Editor/AGXUnityEditor/InspectorGUI.cs
@@ -273,6 +273,93 @@ namespace AGXUnityEditor
       return EditorGUILayout.Toggle( content, value );
     }
 
+    public static bool Toggle( MiscIcon icon,
+                               bool active,
+                               bool enabled,
+                               string tooltip = "",
+                               params GUILayoutOption[] options )
+    {
+
+      return Toggle( icon,
+                     active,
+                     enabled,
+                     InspectorEditor.Skin.ButtonMiddle,
+                     tooltip,
+                     1.0f,
+                     options );
+    }
+
+    public static bool Toggle( MiscIcon icon,
+                               bool active,
+                               bool enabled,
+                               string tooltip = "",
+                               float buttonScale = 1.0f,
+                               params GUILayoutOption[] options )
+    {
+
+      return Toggle( icon,
+                     active,
+                     enabled,
+                     InspectorEditor.Skin.ButtonMiddle,
+                     tooltip,
+                     buttonScale,
+                     options );
+    }
+
+    public static bool Toggle( MiscIcon icon,
+                               bool active,
+                               bool enabled,
+                               GUIStyle buttonStyle,
+                               string tooltip = "",
+                               float iconScale = 1.0f,
+                               params GUILayoutOption[] options )
+    {
+      s_miscIconButtonContent.tooltip = tooltip;
+      var result = GUILayout.Toggle( active,
+                                     s_miscIconButtonContent,
+                                     buttonStyle,
+                                     options );
+      ButtonIcon( GUILayoutUtility.GetLastRect(), icon, enabled, iconScale );
+
+      return result;
+    }
+
+    public static bool Toggle( Rect rect,
+                               MiscIcon icon,
+                               bool active,
+                               bool enabled,
+                               string tooltip = "",
+                               float iconScale = 1.0f )
+    {
+      return Toggle( rect,
+                     icon,
+                     active,
+                     enabled,
+                     InspectorEditor.Skin.ButtonMiddle,
+                     tooltip,
+                     iconScale );
+    }
+
+    public static bool Toggle( Rect rect,
+                               MiscIcon icon,
+                               bool active,
+                               bool enabled,
+                               GUIStyle buttonStyle,
+                               string tooltip = "",
+                               float iconScale = 1.0f )
+    {
+      s_miscIconButtonContent.tooltip = tooltip;
+      var result = false;
+      using ( new GUI.EnabledBlock( enabled ) )
+        result = UnityEngine.GUI.Toggle( rect,
+                                         active,
+                                         s_miscIconButtonContent,
+                                         buttonStyle );
+      ButtonIcon( rect, icon, enabled, iconScale );
+
+      return result;
+    }
+
     public static bool Foldout( EditorDataEntry state, GUIContent content, Action<bool> onStateChanged = null )
     {
       // There's a indentation bug (a few pixels off) in EditorGUILayout.Foldout.
@@ -619,10 +706,14 @@ namespace AGXUnityEditor
     {
       var texture = IconManager.GetIcon( data.Icon );
       var pressed = false;
-      using ( new GUI.EnabledBlock( data.Enabled ) )
-        pressed = UnityEngine.GUI.Button( rect,
-                                          ToolButtonTooltip( data.Tooltip ),
-                                          InspectorEditor.Skin.GetButton( data.IsActive, buttonType ) );
+      using ( new GUI.EnabledBlock( data.Enabled ) ) {
+        var active = UnityEngine.GUI.Toggle( rect,
+                                             data.IsActive,
+                                             ToolButtonTooltip( data.Tooltip ),
+                                             InspectorEditor.Skin.GetButton( buttonType ) );
+        pressed = active != data.IsActive;
+      }
+
       if ( texture != null ) {
         using ( IconManager.ForegroundColorBlock( data.IsActive, data.Enabled ) )
           UnityEngine.GUI.DrawTexture( IconManager.GetIconRect( rect ), texture );

--- a/Editor/AGXUnityEditor/InspectorGUISkin.cs
+++ b/Editor/AGXUnityEditor/InspectorGUISkin.cs
@@ -23,19 +23,11 @@ namespace AGXUnityEditor
 
     public GUIStyle Button { get; private set; } = null;
 
-    public GUIStyle ButtonActive { get; private set; } = null;
-
     public GUIStyle ButtonLeft { get; private set; } = null;
-
-    public GUIStyle ButtonLeftActive { get; private set; } = null;
 
     public GUIStyle ButtonMiddle { get; private set; } = null;
 
-    public GUIStyle ButtonMiddleActive { get; private set; } = null;
-
     public GUIStyle ButtonRight { get; private set; } = null;
-
-    public GUIStyle ButtonRightActive { get; private set; } = null;
 
     public GUIStyle Label { get; private set; } = null;
 
@@ -74,16 +66,13 @@ namespace AGXUnityEditor
 #endif
 
     /// <summary>
-    /// Button style given active state and button type.
+    /// Button style given button type.
     /// </summary>
-    /// <param name="active">True if the button is active, i.e., pressed (e.g., when a tool is active).</param>
     /// <param name="type">Button type; left, middle, right or normal.</param>
     /// <returns>Button style to use.</returns>
-    public GUIStyle GetButton( bool active, ButtonType type = ButtonType.Normal )
+    public GUIStyle GetButton( ButtonType type = ButtonType.Normal )
     {
-      return active ?
-               m_buttonActiveStyles[ (int)type ] :
-               m_buttonStyles[ (int)type ];
+      return m_buttonStyles[ (int)type ];
     }
 
     public string TagTypename( string typename )
@@ -115,25 +104,21 @@ namespace AGXUnityEditor
       {
         richText = true
       };
-      ButtonActive = InvertStyle( Button );
 
       ButtonLeft = new GUIStyle( EditorStyles.miniButtonLeft )
       {
         richText = true
       };
-      ButtonLeftActive = InvertStyle( ButtonLeft );
 
       ButtonMiddle = new GUIStyle( EditorStyles.miniButtonMid )
       {
         richText = true
       };
-      ButtonMiddleActive = InvertStyle( ButtonMiddle );
 
       ButtonRight = new GUIStyle( EditorStyles.miniButtonRight )
       {
         richText = true
       };
-      ButtonRightActive = InvertStyle( ButtonRight );
 
       m_buttonStyles = new GUIStyle[]
       {
@@ -141,14 +126,6 @@ namespace AGXUnityEditor
         ButtonLeft,
         ButtonMiddle,
         ButtonRight
-      };
-
-      m_buttonActiveStyles = new GUIStyle[]
-      {
-        ButtonActive,
-        ButtonLeftActive,
-        ButtonMiddleActive,
-        ButtonRightActive
       };
 
       Label = new GUIStyle( EditorStyles.label )
@@ -178,15 +155,6 @@ namespace AGXUnityEditor
 
     }
 
-    private GUIStyle InvertStyle( GUIStyle org )
-    {
-      return new GUIStyle( org )
-      {
-        normal = org.active,
-        active = org.normal
-      };
-    }
-
     private GUIStyle AnchorStyle( GUIStyle org, TextAnchor anchor )
     {
       return new GUIStyle( org )
@@ -196,7 +164,6 @@ namespace AGXUnityEditor
     }
 
     private GUIStyle[] m_buttonStyles = null;
-    private GUIStyle[] m_buttonActiveStyles = null;
     private static InspectorGUISkin s_instance = null;
   }
 }

--- a/Editor/AGXUnityEditor/Tools/AssemblyTool.cs
+++ b/Editor/AGXUnityEditor/Tools/AssemblyTool.cs
@@ -274,11 +274,12 @@ namespace AGXUnityEditor.Tools
                                                         skin.Button,
                                                         GUILayout.Width( 128 ) );
           UnityEngine.GUI.enabled = m_selection.Count > 0 && Assembly.GetComponentInChildren<RigidBody>() != null;
-          addToExistingRigidBodyPressed = GUILayout.Button( GUI.MakeLabel( "Add to existing",
+          addToExistingRigidBodyPressed = GUILayout.Toggle( m_subMode == SubMode.SelectRigidBody,
+                                                            GUI.MakeLabel( "Add to existing",
                                                                            false,
                                                                            "Add selected objects to existing rigid body" ),
-                                                            skin.GetButton( m_subMode == SubMode.SelectRigidBody ),
-                                                            GUILayout.Width( 100 ) );
+                                                            skin.Button,
+                                                            GUILayout.Width( 100 ) ) != ( m_subMode == SubMode.SelectRigidBody );
           UnityEngine.GUI.enabled = selectionHasRigidBody;
           moveToNewRigidBodyPressed = GUILayout.Button( GUI.MakeLabel( "Move to new",
                                                                        false,

--- a/Editor/AGXUnityEditor/Tools/ConstraintTool.cs
+++ b/Editor/AGXUnityEditor/Tools/ConstraintTool.cs
@@ -287,22 +287,22 @@ namespace AGXUnityEditor.Tools
           var refVsConActive = !EditorGUI.showMixedValue &&
                                state == Constraint.ECollisionsState.DisableReferenceVsConnected;
 
-          if ( GUILayout.Button( GUI.MakeLabel( "Rb " + GUI.Symbols.ArrowLeftRight.ToString() + " Rb",
+          if ( GUILayout.Toggle( rbVsRbActive,
+                                 GUI.MakeLabel( "Rb " + GUI.Symbols.ArrowLeftRight.ToString() + " Rb",
                                                 rbVsRbActive,
                                                 "Disable all shapes in rigid body 1 against all shapes in rigid body 2." ),
-                                  skin.GetButton( rbVsRbActive,
-                                                  InspectorGUISkin.ButtonType.Left ),
-                                  GUILayout.Width( 76 ) ) )
+                                  skin.GetButton( InspectorGUISkin.ButtonType.Left ),
+                                  GUILayout.Width( 76 ) ) != rbVsRbActive )
             state = state == Constraint.ECollisionsState.DisableRigidBody1VsRigidBody2 ?
                       Constraint.ECollisionsState.KeepExternalState :
                       Constraint.ECollisionsState.DisableRigidBody1VsRigidBody2;
 
-          if ( GUILayout.Button( GUI.MakeLabel( "Ref " + GUI.Symbols.ArrowLeftRight.ToString() + " Con",
+          if ( GUILayout.Toggle( refVsConActive,
+                                 GUI.MakeLabel( "Ref " + GUI.Symbols.ArrowLeftRight.ToString() + " Con",
                                                 refVsConActive,
                                                 "Disable Reference object vs. Connected object." ),
-                                  skin.GetButton( refVsConActive,
-                                                  InspectorGUISkin.ButtonType.Right ),
-                                  GUILayout.Width( 76 ) ) )
+                                  skin.GetButton( InspectorGUISkin.ButtonType.Right ),
+                                  GUILayout.Width( 76 ) ) != refVsConActive )
             state = state == Constraint.ECollisionsState.DisableReferenceVsConnected ?
                       Constraint.ECollisionsState.KeepExternalState :
                       Constraint.ECollisionsState.DisableReferenceVsConnected;

--- a/Editor/AGXUnityEditor/Utils/ShapeCreateButtons.cs
+++ b/Editor/AGXUnityEditor/Utils/ShapeCreateButtons.cs
@@ -58,13 +58,14 @@ namespace AGXUnityEditor.Utils
                        isFirst                      ? InspectorGUISkin.ButtonType.Left :
                        isLast                       ? InspectorGUISkin.ButtonType.Right :
                                                       InspectorGUISkin.ButtonType.Middle;
-      var toggleDropdown = InspectorGUI.Button( rect,
+      var toggleDropdown = InspectorGUI.Toggle( rect,
                                                 Icon,
+                                                State.DropdownEnabled,
                                                 UnityEngine.GUI.enabled,
-                                                InspectorEditor.Skin.GetButton( true, buttonType ),
+                                                InspectorEditor.Skin.GetButton( buttonType ),
                                                 "Create new " +
                                                 State.ShapeType.ToString().ToLower() +
-                                                "as parent of the selected object(s)." );
+                                                " as parent of the selected object(s)." ) != State.DropdownEnabled;
 
       if ( toggleDropdown )
         State.DropdownEnabled = !State.DropdownEnabled;
@@ -88,7 +89,7 @@ namespace AGXUnityEditor.Utils
 
       using ( InspectorGUI.IndentScope.Create( 2 ) ) {
         var rect = EditorGUI.IndentedRect( EditorGUILayout.GetControlRect( false, 25.0f ) );
-        rect.width = 45.0f;
+        rect.width = 50.0f;
 
         if ( hasRadius ) {
           State.CreatePressed = OnButtonGUI( rect,
@@ -155,7 +156,7 @@ namespace AGXUnityEditor.Utils
       using ( InspectorGUI.IndentScope.Create( 2 ) ) {
         var down = UnityEngine.GUI.Button( rect,
                                            GUI.MakeLabel( name ),
-                                           InspectorEditor.Skin.GetButton( true, buttonType ) );
+                                           InspectorEditor.Skin.GetButton( buttonType ) );
         if ( current.type == EventType.Repaint &&
              rect.Contains( current.mousePosition ) )
           onMouseOver();


### PR DESCRIPTION
### Fixes
- Using Toggle instead of Button with inverted button styles, which hasn't worked since Unity 2019.2. ([f876e02](https://github.com/Algoryx/AGXUnity/commit/f876e02b92e03d0583fd82d0eccec01bac9572df))
- Fixed bug where the collision state of constraints propagated too far in articulated systems. ([0a0d02e](https://github.com/Algoryx/AGXUnity/commit/0a0d02e67bfe26466f588ce1a12fa8b71ad1d434))
- Avoiding unnecessary calls to `UnityEditor.SceneView.RepaintAll` resolving high CPU usage of the Editor. ([dfd63da](https://github.com/Algoryx/AGXUnity/pull/72/commits/dfd63daf2bb9d7302d98aed355980676c4410a5e))