### PR TITLE
Save URDF model assets and/or prefab.

### DIFF
--- a/AGXUnity/IO/URDF/Element.cs
+++ b/AGXUnity/IO/URDF/Element.cs
@@ -28,7 +28,7 @@ namespace AGXUnity.IO.URDF
     /// Name attribute of the element.
     /// </summary>
     [HideInInspector]
-    public string Name { get { return m_name; } private set { m_name = value; } }
+    public string Name { get { return m_name; } private set { name = m_name = value; } }
 
     /// <summary>
     /// Line number this element is located in the read URDF document.

--- a/AGXUnity/IO/URDF/Utils.cs
+++ b/AGXUnity/IO/URDF/Utils.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
-using System.Globalization;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -211,7 +211,7 @@ namespace AGXUnity.IO.URDF
           var lineNumber = 0;
           while ( ++lineNumber <= maxNumLines && (line = stream.ReadLine()) != null ) {
             if ( assetElement == null && line.TrimStart().StartsWith( "<asset>" ) ) {
-              assetElement = new System.Collections.Generic.List<string>();
+              assetElement = new List<string>();
               assetElement.Add( line );
             }
             else if ( assetElement != null && line.TrimStart().StartsWith( "</asset>" ) ) {
@@ -228,6 +228,53 @@ namespace AGXUnity.IO.URDF
       }
 
       return assetElement?.ToArray();
+    }
+
+    public static T GetElement<T>( GameObject gameObject )
+      where T : ScriptableObject
+    {
+      if ( gameObject == null )
+        return null;
+      var components = gameObject.GetComponents<ElementComponent>();
+      foreach ( var component in components )
+        if ( component.Element is T element )
+          return element;
+      return null;
+    }
+
+    public static T GetElementInChildren<T>( GameObject gameObject )
+      where T : ScriptableObject
+    {
+      if ( gameObject == null )
+        return null;
+      var components = gameObject.GetComponentsInChildren<ElementComponent>();
+      foreach ( var component in components )
+        if ( component.Element is T element )
+          return element;
+      return null;
+    }
+
+    public static T[] GetElementsInChildren<T>( GameObject gameObject )
+      where T : ScriptableObject
+    {
+      if ( gameObject == null )
+        return new T[] { };
+
+      var components = gameObject.GetComponentsInChildren<ElementComponent>();
+      return ( from component in components
+               where component.Element is T
+               select component.Element as T ).ToArray();
+    }
+
+    public static GameObject FindGameObjectWithElement( GameObject rootGameObject, Element element )
+    {
+      if ( rootGameObject == null )
+        return null;
+      var components = rootGameObject.GetComponentsInChildren<ElementComponent>();
+      foreach ( var component in components )
+        if ( component.Element == element )
+          return component.gameObject;
+      return null;
     }
   }
 }

--- a/Editor/AGXUnityEditor/IO/URDF/Prefab.cs
+++ b/Editor/AGXUnityEditor/IO/URDF/Prefab.cs
@@ -1,0 +1,238 @@
+﻿using System.Linq;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using AGXUnity.IO.URDF;
+
+using Material = AGXUnity.IO.URDF.Material;
+using Collision = AGXUnity.IO.URDF.Collision;
+
+namespace AGXUnityEditor.IO.URDF
+{
+  public static class Prefab
+  {
+    public static GameObject Create( Model model, GameObject modelGameObject = null )
+    {
+      if ( model == null )
+        return null;
+
+      if ( !System.IO.Directory.Exists( CachedCreatedDirectoryData.String ) )
+        CachedCreatedDirectoryData.String = "Assets";
+
+      var directory = EditorUtility.OpenFolderPanel( "URDF Prefab Directory",
+                                                     CachedCreatedDirectoryData.String,
+                                                     string.Empty );
+      if ( string.IsNullOrEmpty( directory ) )
+        return null;
+
+      directory = FileUtil.GetProjectRelativePath( directory );
+
+      if ( System.IO.Directory.Exists( directory ) && !AssetDatabase.IsValidFolder( directory ) ) {
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+      }
+
+      return Create( model, directory );
+    }
+
+    public static GameObject Create( Model model, string directory, GameObject modelGameObject = null )
+    {
+      if ( model == null )
+        return null;
+
+      directory = FileUtil.GetProjectRelativePath( directory );
+
+      if ( !AssetDatabase.IsValidFolder( directory ) ) {
+        Debug.LogWarning( $"URDF Prefab: Unable to create URDF prefab, directory {directory} isn't a valid project folder." );
+        return null;
+      }
+
+      // Check if the model is saved from click in the Inspector,
+      // and the model belongs to the selected game object.
+      if ( modelGameObject == null &&
+           Selection.activeGameObject?.GetComponent<ElementComponent>()?.Element as Model == model ) {
+        modelGameObject = Selection.activeGameObject;
+      }
+      // Check so that modelGameObject is the root of the model.
+      else if ( modelGameObject != null &&
+                modelGameObject.GetComponent<ElementComponent>()?.Element as Model != model ) {
+        Debug.LogWarning( $"URDF Prefab: Given model game object \"{modelGameObject.name}\" doesn't contain the " +
+                          $"given URDF model \"{model.Name}\". Ignoring the given game object.", modelGameObject );
+        modelGameObject = null;
+      }
+
+      CachedCreatedDirectoryData.String = directory;
+
+      // Collecting STL meshes and visual with materials.
+      var meshesToSave    = new List<Mesh>();
+      var materialsToSave = new List<UnityEngine.Material>();
+      var collisions      = new List<Collision>();
+      var visuals         = new List<Visual>();
+      var geometries      = new List<Geometry>();
+      var urdfMaterials   = new List<Material>();
+      System.Action<Link> CollectAndNameLinkAssets = link =>
+      {
+        CollectAndNameAssets( link.Collisions,
+                              collision => collision,
+                              link.name,
+                              "Collision",
+                              collisions );
+        CollectAndNameAssets( link.Visuals,
+                              visual => visual,
+                              link.name,
+                              "Visual",
+                              visuals );
+        CollectAndNameAssets( link.Collisions,
+                              collision => collision.Geometry,
+                              link.name,
+                              "CollisionGeometry",
+                              geometries );
+        CollectAndNameAssets( link.Visuals,
+                              visual => visual.Geometry,
+                              link.name,
+                              "VisualGeometry",
+                              geometries );
+        CollectAndNameAssets( link.Visuals,
+                              visual => visual.Material,
+                              link.name,
+                              "VisualMaterial",
+                              urdfMaterials );
+      };
+
+      // Traversing modelGameObject (if valid) to collect visual materials
+      // and STL meshes. Those two entities are only available if we have
+      // access to the game object and components. Geometries are also
+      // collected and named here.
+      if ( modelGameObject != null ) {
+        Traverse( modelGameObject, ( go, element ) =>
+        {
+          if ( element is Link link ) {
+            CollectAndNameLinkAssets( link );
+          }
+          else if ( element is Collision collision ) {
+            if ( collision.Geometry.ResourceType == Geometry.MeshResourceType.STL &&
+                 go.GetComponent<AGXUnity.Collide.Mesh>() != null ) {
+              var collisionMesh = go.GetComponent<AGXUnity.Collide.Mesh>();
+              CollectAndNameAssets( collisionMesh.SourceObjects,
+                                    cMesh => cMesh,
+                                    go.name,
+                                    "CollisionMesh",
+                                    meshesToSave );
+            }
+          }
+          else if ( element is Visual visual ) {
+            var saveMaterial = visual.Material != null ||
+                               visual.Geometry.ResourceType == Geometry.MeshResourceType.STL;
+            var saveMesh = visual.Geometry.ResourceType == Geometry.MeshResourceType.STL;
+            if ( saveMaterial ) {
+              var renderers = go.GetComponentsInChildren<MeshRenderer>();
+              CollectAndNameAssets( renderers,
+                                    renderer => renderer.sharedMaterial,
+                                    go.name,
+                                    "RenderMaterial",
+                                    materialsToSave );
+            }
+            if ( saveMesh ) {
+              var filters = go.GetComponentsInChildren<MeshFilter>();
+              CollectAndNameAssets( filters,
+                                    filter => filter.sharedMesh,
+                                    go.name,
+                                    "RenderMesh",
+                                    meshesToSave );
+            }
+          }
+        } );
+      }
+      else {
+        Debug.LogWarning( $"URDF Prefab: The model game object is null, STL meshes and visual materials " +
+                          $"won't be exported as assets.", model );
+
+        foreach ( var link in model.Links )
+          CollectAndNameLinkAssets( link );
+      }
+
+      var rootAssetsName = modelGameObject != null ?
+                             modelGameObject.name :
+                             model.Name;
+      AssetDatabase.CreateAsset( model, $"{directory}/{rootAssetsName}_Model.asset" );
+
+      materialsToSave = ( from visualMaterial in materialsToSave
+                          where !IsAsset( visualMaterial )
+                          select visualMaterial ).Distinct().ToList();
+      if ( materialsToSave.Count > 0 ) {
+        AssetDatabase.CreateAsset( materialsToSave[ 0 ], $"{directory}/{rootAssetsName}_VisualMaterials.mat" );
+        for ( int i = 1; i < materialsToSave.Count; ++i )
+          AssetDatabase.AddObjectToAsset( materialsToSave[ i ], materialsToSave[ 0 ] );
+      }
+
+      meshesToSave = ( from mesh in meshesToSave
+                       where !IsAsset( mesh )
+                       select mesh ).Distinct().ToList();
+      foreach ( var mesh in meshesToSave )
+        AssetDatabase.AddObjectToAsset( mesh, model );
+
+      foreach ( var material in urdfMaterials )
+        AssetDatabase.AddObjectToAsset( material, model );
+      foreach ( var geometry in geometries )
+        AssetDatabase.AddObjectToAsset( geometry, model );
+      foreach ( var collision in collisions )
+        AssetDatabase.AddObjectToAsset( collision, model );
+      foreach ( var visual in visuals )
+        AssetDatabase.AddObjectToAsset( visual, model );
+      foreach ( var link in model.Links )
+        AssetDatabase.AddObjectToAsset( link, model );
+      foreach ( var joint in model.Joints )
+        AssetDatabase.AddObjectToAsset( joint, model );
+
+      AssetDatabase.Refresh();
+      AssetDatabase.SaveAssets();
+
+      return null;
+    }
+
+    private static void Traverse( GameObject go, System.Action<GameObject, Element> callback )
+    {
+      if ( go == null || callback == null )
+        return;
+
+      var element = go.GetComponent<ElementComponent>()?.Element;
+      if ( element != null )
+        callback( go, element );
+
+      foreach ( Transform child in go.transform )
+        Traverse( child.gameObject, callback );
+    }
+
+    private static void CollectAndNameAssets<T, U>( T[] origins,
+                                                    System.Func<T, U> transformer,
+                                                    string parentName,
+                                                    string identifier,
+                                                    List<U> result )
+      where T : Object
+      where U : Object
+    {
+      var counter = 0;
+      foreach ( var origin in origins ) {
+        var asset = transformer( origin );
+        if ( asset == null || result.Contains( asset ) )
+          continue;
+
+        if ( string.IsNullOrEmpty( asset.name ) )
+          asset.name = $"{parentName}_{identifier}" +
+                       ( origins.Length > 1 ? $"_{counter++}" :
+                         string.Empty );
+
+        result.Add( asset );
+      }
+    }
+
+    private static bool IsAsset( Object @object )
+    {
+      return @object != null &&
+             !string.IsNullOrEmpty( AssetDatabase.GetAssetPath( @object.GetInstanceID() ) );
+    }
+
+    private static EditorDataEntry CachedCreatedDirectoryData => EditorData.Instance.GetStaticData( "URDF.Prefab_CreateDirectory",
+                                                                                                    entry => entry.String = "Assets" );
+  }
+}

--- a/Editor/AGXUnityEditor/IO/URDF/Prefab.cs
+++ b/Editor/AGXUnityEditor/IO/URDF/Prefab.cs
@@ -65,12 +65,18 @@ namespace AGXUnityEditor.IO.URDF
       if ( !CreateAssets( model, rootGameObject, directory, rootAssetsName ) )
         return null;
 
+      var isPrefab = PrefabUtility.GetPrefabInstanceStatus( rootGameObject ) == PrefabInstanceStatus.Connected;
+      GameObject prefab = null;
       var prefabPath = $"{directory}/{rootAssetsName}.prefab";
-      var prefab = PrefabUtility.SaveAsPrefabAssetAndConnect( rootGameObject,
-                                                              prefabPath,
-                                                              InteractionMode.AutomatedAction );
+      if ( isPrefab )
+        prefab = PrefabUtility.GetCorrespondingObjectFromSource( rootGameObject );
+      else {
+        prefab = PrefabUtility.SaveAsPrefabAssetAndConnect( rootGameObject,
+                                                            prefabPath,
+                                                            InteractionMode.AutomatedAction );
+      }
       if ( prefab != null )
-        Debug.Log( $"URDF Prefab: Prefab {rootAssetsName} successfully saved to {prefabPath}." );
+        Debug.Log( $"URDF Prefab: Prefab {prefab.name} successfully saved in {AssetDatabase.GetAssetPath( prefab )}." );
 
       return prefab;
     }

--- a/Editor/AGXUnityEditor/IO/URDF/Prefab.cs.meta
+++ b/Editor/AGXUnityEditor/IO/URDF/Prefab.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9676e9d25f44f764b996123a5c127db4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AGXUnityEditor/InvokeWrapperInspectorDrawer.cs
+++ b/Editor/AGXUnityEditor/InvokeWrapperInspectorDrawer.cs
@@ -584,6 +584,12 @@ namespace AGXUnityEditor
       if ( element == null )
         return;
 
+      var isModel = element is AGXUnity.IO.URDF.Model;
+      if ( isModel ) {
+        if ( GUILayout.Button( GUI.MakeLabel( "Do it!" ) ) )
+          IO.URDF.Prefab.Create( element as AGXUnity.IO.URDF.Model );
+      }
+
       var dropDownName = string.IsNullOrEmpty( element.Name ) ?
                             elementArrayIndex >= 0 ?
                               $"{element.GetType().Name}[{elementArrayIndex}]" :
@@ -596,6 +602,11 @@ namespace AGXUnityEditor
         return;
 
       using ( InspectorGUI.IndentScope.Single ) {
+        if ( isModel ) {
+          var assetPath = AssetDatabase.GetAssetPath( element );
+          InspectorGUI.SelectableTextField( GUI.MakeLabel( "Asset Path" ), assetPath );
+        }
+
         var ignoreName = element is AGXUnity.IO.URDF.Inertial;
         if ( !ignoreName ) {
           var nameRect = EditorGUILayout.GetControlRect();

--- a/Editor/AGXUnityEditor/InvokeWrapperInspectorDrawer.cs
+++ b/Editor/AGXUnityEditor/InvokeWrapperInspectorDrawer.cs
@@ -584,12 +584,6 @@ namespace AGXUnityEditor
       if ( element == null )
         return;
 
-      var isModel = element is AGXUnity.IO.URDF.Model;
-      if ( isModel ) {
-        if ( GUILayout.Button( GUI.MakeLabel( "Do it!" ) ) )
-          IO.URDF.Prefab.Create( element as AGXUnity.IO.URDF.Model );
-      }
-
       var dropDownName = string.IsNullOrEmpty( element.Name ) ?
                             elementArrayIndex >= 0 ?
                               $"{element.GetType().Name}[{elementArrayIndex}]" :
@@ -602,9 +596,49 @@ namespace AGXUnityEditor
         return;
 
       using ( InspectorGUI.IndentScope.Single ) {
-        if ( isModel ) {
-          var assetPath = AssetDatabase.GetAssetPath( element );
-          InspectorGUI.SelectableTextField( GUI.MakeLabel( "Asset Path" ), assetPath );
+        if ( element is AGXUnity.IO.URDF.Model model ) {
+          var isSelectedPrefab = PrefabUtility.GetPrefabInstanceStatus( Selection.activeGameObject ) == PrefabInstanceStatus.Connected;
+          var modelAssetPath = AssetDatabase.GetAssetPath( element );
+
+          var savePrefabRect = EditorGUI.IndentedRect( EditorGUILayout.GetControlRect() );
+          savePrefabRect.width = InspectorGUISkin.ToolButtonSize.x;
+          savePrefabRect.height = InspectorGUISkin.ToolButtonSize.y;
+          var savePrefab = InspectorGUI.Button( savePrefabRect,
+                                                MiscIcon.Locate,
+                                                !isSelectedPrefab,
+                                                "Save game object as prefab and all URDF elements, STL meshes and render materials in project.",
+                                                1.1f );
+          savePrefabRect.x += savePrefabRect.width;
+          savePrefabRect.xMax += savePrefabRect.width;
+          savePrefabRect.width = InspectorGUISkin.ToolButtonSize.x;
+          var saveAssets = false;
+          using ( new GUI.EnabledBlock( string.IsNullOrEmpty( modelAssetPath ) ) ) {
+            saveAssets = UnityEngine.GUI.Button( savePrefabRect,
+                                                 GUI.MakeLabel( "",
+                                                                false,
+                                                                "Save all URDF elements, STL meshes and render materials in project." ),
+                                                 InspectorEditor.Skin.ButtonMiddle );
+
+            savePrefabRect.x -= 6.0f;
+            savePrefabRect.y -= 4.0f;
+            InspectorGUI.ButtonIcon( savePrefabRect,
+                                     MiscIcon.Locate,
+                                     UnityEngine.GUI.enabled,
+                                     0.75f );
+            savePrefabRect.x += 2.0f * 6.0f - 1.0f;
+            savePrefabRect.y += 2.0f * 4.0f - 2.0f;
+            InspectorGUI.ButtonIcon( savePrefabRect,
+                                     MiscIcon.Locate,
+                                     UnityEngine.GUI.enabled,
+                                     0.75f );
+          }
+
+          if ( savePrefab )
+            IO.URDF.Prefab.Create( model );
+          if ( saveAssets )
+            IO.URDF.Prefab.CreateAssets( model );
+
+          InspectorGUI.SelectableTextField( GUI.MakeLabel( "Asset Path" ), modelAssetPath );
         }
 
         var ignoreName = element is AGXUnity.IO.URDF.Inertial;

--- a/Editor/AGXUnityEditor/Menus/AssetsMenu.cs
+++ b/Editor/AGXUnityEditor/Menus/AssetsMenu.cs
@@ -102,6 +102,40 @@ namespace AGXUnityEditor
       return instances;
     }
 
+    [MenuItem( "Assets/AGXUnity/Import/Selected URDF [prefab]...", validate = true, priority = 550 )]
+    public static bool IsUrdfSelectedAsPrefab()
+    {
+      return IsUrdfSelected();
+    }
+
+    [MenuItem( "Assets/AGXUnity/Import/Selected URDF [prefab]...", priority = 550 )]
+    public static GameObject[] SelectedUrdfFilesAsPrefab()
+    {
+      var urdfFilePaths = IO.URDF.Reader.GetSelectedUrdfFiles( true );
+      var instances = IO.URDF.Reader.Instantiate( urdfFilePaths, null, false );
+      if ( instances.Length == 0 )
+        return instances;
+
+      var prefabs = new List<GameObject>();
+      foreach ( var instance in instances ) {
+        var directory = IO.URDF.Prefab.OpenFolderPanel( $"Prefab and assets directory for: {instance.name}" );
+        if ( string.IsNullOrEmpty( directory ) ) {
+          Debug.Log( $"Ignoring URDF prefab {instance.name}." );
+          continue;
+        }
+        var model = AGXUnity.IO.URDF.Utils.GetElement<AGXUnity.IO.URDF.Model>( instance );
+        var prefab = IO.URDF.Prefab.Create( model,
+                                            instance,
+                                            directory );
+        if ( prefab != null )
+          prefabs.Add( prefab );
+
+        Object.DestroyImmediate( instance );
+      }
+
+      return prefabs.ToArray();
+    }
+
     [MenuItem( "Assets/AGXUnity/Import/Selected STL [instance]", validate = true, priority = 551 )]
     public static bool IsStlSelected()
     {


### PR DESCRIPTION
### Features
- Added feature to save an URDF model's all generated instances (URDF elements, STL collision and render meshes, render materials) as assets in the project. This can be done by clicking `AGXUnity -> Save -> URDF Model(s) assets...` in the game object context menu (in Hierarchy), button in the Inspector of the URDF model or by calling `AGXUnityEditor.IO.URDF.Prefab.CreateAssets`.
- Added feature to save an URDF model as prefab, with all generated instances. This can be done by clicking `AGXUnity -> Save -> URDF Model(s) as prefab(s)...` in the game object context menu (in Hierarchy), button in the Inspector of the URDF model or by calling `AGXUnityEditor.IO.URDF.Prefab.Create`.
- Added option to import selected URDF file(s) as prefab(s), `AGXUnity -> Import -> Selected URDF [prefab]...`. ([3ae33a9](https://github.com/Algoryx/AGXUnity/pull/73/commits/3ae33a9f1ab17c1e2f5780d8abf2f472a2e6a7ad))