### PR TITLE
Singleton perf

### DIFF
--- a/AGXUnity/CableProperties.cs
+++ b/AGXUnity/CableProperties.cs
@@ -44,10 +44,17 @@ namespace AGXUnity
     [HideInInspector]
     public float PoissonsRatio
     {
-      get { return m_poissonsRatio; }
+      get
+      {
+        // This is rendered in the Inspector by CablePropertiesEditor
+        // in CableTool and will only show up for the Twist direction,
+        // where it's used.
+        return m_poissonsRatio;
+      }
       set
       {
-        m_poissonsRatio = value;
+        // Poisson's ratio at -1.0 will result in a division by 0.
+        m_poissonsRatio = Utils.Math.Clamp( value, -0.999f, 0.5f );
         OnValueCanged( Direction );
       }
     }

--- a/AGXUnity/Collide/Plane.cs
+++ b/AGXUnity/Collide/Plane.cs
@@ -28,7 +28,7 @@ namespace AGXUnity.Collide
     /// <returns></returns>
     protected override agxCollide.Geometry CreateNative()
     {
-      return new agxCollide.Geometry( new agxCollide.Plane( transform.up.ToHandedVec3(), 0 ),
+      return new agxCollide.Geometry( new agxCollide.Plane( agx.Vec3.Y_AXIS(), 0 ),
                                       GetNativeGeometryOffset() );
     }
   }

--- a/AGXUnity/CollisionGroupsManager.cs
+++ b/AGXUnity/CollisionGroupsManager.cs
@@ -50,11 +50,11 @@ namespace AGXUnity
 
     protected override bool Initialize()
     {
-      agxCollide.Space space = GetSimulation().getSpace();
-      foreach ( CollisionGroupEntryPair pair in m_disabledPairs )
+      var space = GetSimulation().getSpace();
+      foreach ( var pair in m_disabledPairs )
         SetEnablePair( pair, false, space );
 
-      return base.Initialize();
+      return true;
     }
 
     private void AddToDisabled( string group1, string group2 )

--- a/AGXUnity/PickHandler.cs
+++ b/AGXUnity/PickHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using UnityEngine;
 using AGXUnity.Utils;
 
@@ -218,15 +219,20 @@ namespace AGXUnity
     {
       if ( ConstraintGameObject == null && m_lineGeometry.isEnabled() ) {
         var geometryContacts = new agxCollide.GeometryContactPtrVector();
-        var numContacts = GetSimulation().getSpace().getGeometryContacts( geometryContacts, m_lineGeometry );
-        if ( numContacts > 0 ) {
+        GetSimulation().getSpace().getGeometryContacts( geometryContacts, m_lineGeometry );
+        var closestGeometryContact = geometryContacts.FirstOrDefault( gc => gc.points().size() > 0 );
+        if ( closestGeometryContact != null ) {
           var ray = m_camera.ScreenPointToRay( Input.mousePosition );
           var rayHandedOrigin = ray.origin.ToHandedVec3();
-          var closestGeometryContact = geometryContacts[ 0 ];
           var closestDistance2 = rayHandedOrigin.distance2( closestGeometryContact.points().at( 0 ).point );
           for ( int i = 1; i < geometryContacts.Count; ++i ) {
             var gc = geometryContacts[ i ];
-            var distance2 = rayHandedOrigin.distance2( gc.points().at( 0 ).point );
+            var points = gc.points();
+            if ( gc == closestGeometryContact || points.size() == 0 )
+              continue;
+
+            var point = points.at( 0u );
+            var distance2 = rayHandedOrigin.distance2( point.point );
             if ( distance2 < closestDistance2 ) {
               closestDistance2 = distance2;
               closestGeometryContact = gc;

--- a/AGXUnity/RuntimeObjects.cs
+++ b/AGXUnity/RuntimeObjects.cs
@@ -111,11 +111,8 @@ namespace AGXUnity
         rootsToRemove.RemoveAt( rootsToRemove.Count - 1 );
       }
 
-      if ( transform.childCount == 0 ) {
+      if ( transform.childCount == 0 )
         DestroyImmediate( gameObject );
-        // Reset destroyed state so that another instance may be created.
-        ResetDestroyedState();
-      }
     }
 
     private static string GetName( MonoBehaviour script )
@@ -125,8 +122,6 @@ namespace AGXUnity
 
     private static RuntimeObjects RecoverAndGetInstance()
     {
-      if ( IsDestroyed && HasInstance )
-        ResetDestroyedState();
       return Instance;
     }
   }

--- a/AGXUnity/ScriptAsset.cs
+++ b/AGXUnity/ScriptAsset.cs
@@ -16,16 +16,16 @@ namespace AGXUnity
   /// ScriptAssetManager to have a "component like" behavior in the
   /// implementations.
   /// </summary>
-  public abstract class ScriptAsset : UnityEngine.ScriptableObject
+  public abstract class ScriptAsset : ScriptableObject
   {
     public static T Create<T>() where T : ScriptAsset
     {
       return Create( typeof( T ) ) as T;
     }
 
-    public static ScriptAsset Create( System.Type type )
+    public static ScriptAsset Create( Type type )
     {
-      ScriptAsset instance = CreateInstance( type ) as ScriptAsset;
+      var instance = CreateInstance( type ) as ScriptAsset;
       instance.Construct();
 
       return instance;
@@ -40,7 +40,7 @@ namespace AGXUnity
       if ( ScriptAssetManager.Instance == null )
         throw new AGXUnity.Exception( "Script asset manager seems to be destroyed. Is your script trying to access an initialized script asset outside of start/initialize -> destroy?" );
 
-      ScriptAssetManager.InitializationState state = ScriptAssetManager.Instance.Report( this );
+      var state = ScriptAssetManager.Instance.Report( this );
       if ( state == ScriptAssetManager.InitializationState.NotInitialized ) {
         NativeHandler.Instance.MakeMainThread();
 

--- a/AGXUnity/ScriptAssetManager.cs
+++ b/AGXUnity/ScriptAssetManager.cs
@@ -61,7 +61,7 @@ namespace AGXUnity
 
     protected override bool Initialize()
     {
-      return base.Initialize();
+      return true;
     }
 
     /// <summary>

--- a/AGXUnity/ScriptComponent.cs
+++ b/AGXUnity/ScriptComponent.cs
@@ -42,8 +42,10 @@ namespace AGXUnity
     /// <returns>Native simulation object if not being destructed.</returns>
     public agxSDK.Simulation GetSimulation()
     {
-      Simulation simulation = Simulation.Instance;
-      return simulation ? simulation.Native : null;
+      if ( Simulation.IsDestroyed )
+        return null;
+
+      return Simulation.Instance?.Native;
     }
 
     /// <summary>

--- a/AGXUnity/Simulation.cs
+++ b/AGXUnity/Simulation.cs
@@ -311,7 +311,7 @@ namespace AGXUnity
 
       m_stepForwardTimer = new agx.Timer();
 
-      return base.Initialize();
+      return true;
     }
 
     protected override void OnDestroy()

--- a/AGXUnity/UniqueGameObject.cs
+++ b/AGXUnity/UniqueGameObject.cs
@@ -6,109 +6,19 @@ using Scene = UnityEngine.SceneManagement.Scene;
 namespace AGXUnity
 {
   /// <summary>
-  /// Singleton like object that is created when Instance is called
-  /// AND this object hasn't been destroyed in the Unity Engine.
-  /// 
-  /// This means that there can only be one instance of this type in
-  /// a scene and that it is unsafe to use this object in the OnDestroy
-  /// callbacks.
-  /// 
-  /// If this object has been destroyed, Instance will return null!
+  /// Singleton like object that is created when Instance is called.
+  /// It's important that callers to Instance properly checks
+  /// HasInstance and/or IsDestroyed when the caller is being
+  /// destroyed, e.g., during scene unload or from OnDestroy.
   /// </summary>
   /// <typeparam name="T">Type of subclass.</typeparam>
   public class UniqueGameObject<T> : ScriptComponent
     where T : ScriptComponent
   {
-#if OLD_SINGLETON
-    protected static T m_instance     = null;
-    protected static bool m_destroyed = false;
-
     /// <summary>
-    /// Returns an instance of this object if it hasn't been destroyed
-    /// in the current context (Unity scene).
+    /// Get found instance or finds instance in the current scene or
+    /// creates a new instance in the scene.
     /// </summary>
-    /// <remarks>
-    /// Note that this property may return null, and if it does, one
-    /// probably wouldn't need the object anyway.
-    /// </remarks>
-    public static T Instance
-    {
-      get
-      {
-        if ( m_destroyed && !Application.isPlaying )
-          ResetDestroyedState();
-
-        var wasNull = m_instance == null;
-
-        if ( !m_destroyed && m_instance == null && ( m_instance = FindObjectOfType( typeof( T ) ) as T ) == null ) {
-          string name = ( typeof( T ).Namespace != null ? typeof( T ).Namespace + "." : "" ) + typeof( T ).Name;
-          m_instance = ( new GameObject( name ) ).AddComponent<T>();
-          m_instance.transform.hideFlags = HideFlags.NotEditable;
-        }
-
-        // When a scene has been unloaded it's safe to create
-        // an instance of this singleton again.
-        if ( wasNull && m_instance != null )
-          SceneManager.sceneUnloaded += OnSceneUnloaded;
-
-        return m_instance;
-      }
-    }
-
-    // (FindObjectOfType( typeof( T ) ) as T ) != null
-    public static bool HasInstance => m_instance != null;
-
-    public static bool InstanceFound => m_instance != null || ( FindObjectOfType( typeof( T ) ) as T ) != null;
-
-    public static bool IsDestroyed { get { return m_destroyed; } }
-
-    /// <summary>
-    /// Use with care. Reset the internal reset state so this
-    /// object may be created again.
-    /// 
-    /// Only call/use this method when you are in the editor!
-    /// </summary>
-    public static void ResetDestroyedState()
-    {
-      m_destroyed = false;
-    }
-
-    protected virtual bool OnInitialize() => true;
-
-    protected override void OnAwake()
-    {
-      m_destroyed = false;
-
-      base.OnAwake();
-    }
-
-    protected sealed override bool Initialize()
-    {
-      // TODO: This isn't the right way to do it. Refactor this class!
-      // https://gamedev.stackexchange.com/questions/116009/in-unity-how-do-i-correctly-implement-the-singleton-pattern
-      int WARNING_READ_TODO;
-      if ( !OnInitialize() )
-        return false;
-
-      if ( m_instance == null )
-        m_instance = this as T;
-
-      return true;
-    }
-
-    protected override void OnDestroy()
-    {
-      m_destroyed = true;
-
-      base.OnDestroy();
-    }
-
-    private static void OnSceneUnloaded( Scene scene )
-    {
-      ResetDestroyedState();
-      SceneManager.sceneUnloaded -= OnSceneUnloaded;
-    }
-#else
     public static T Instance
     {
       get
@@ -122,10 +32,26 @@ namespace AGXUnity
       }
     }
 
+    /// <summary>
+    /// True if the instance has been found or been created.
+    /// False if destroyed or no one has called Instance.
+    /// </summary>
     public static bool HasInstance => s_instance != null;
 
+    /// <summary>
+    /// True if this object has been destroyed. Calling Instance
+    /// after this will create a new instance so if IsDestroyed == true,
+    /// don't call Instance from OnDestroy.
+    /// </summary>
     public static bool IsDestroyed => s_wasCreated && s_instance == null;
 
+    /// <summary>
+    /// True if an instance has been created or there is an instance
+    /// in the loaded scenes. This is used by implicit dependent scripts
+    /// on certain managers, e.g., WindAndWaterParameters shouldn't
+    /// instantiate a dependent WindAndWaterManager if the user hasn't
+    /// explicitly enabled a WindAndWaterManager in a loaded scene.
+    /// </summary>
     public static bool HasInstanceInScene
     {
       get
@@ -136,31 +62,52 @@ namespace AGXUnity
 
     protected sealed override void OnAwake()
     {
-      Instance = this as T;
+      // In adaptive scene loading it's possible that we
+      // have multiple instances of some managers. It's
+      // likely they communicate with the same simulation
+      // instance or may operate separately as long as no
+      // external script depends on calls to Instance.
+      // E.g., ContactMaterialManager and CollisionGroupsManager
+      // may have several instances. Simulation and
+      // ScriptAssetManager may not, so either they has
+      // to be in the main scene or in no scene at all.
+      if ( s_instance == null )
+        Instance = this as T;
     }
 
     protected override void OnDestroy()
     {
-      Debug.Log( $"OnDestroy: {typeof( T ).FullName}, {s_instance != null}" );
-      Instance = null;
+      if ( s_instance == this )
+        Instance = null;
 
       base.OnDestroy();
     }
 
+    /// <summary>
+    /// Invalid to call this method if s_instance != null. Finds
+    /// instance in scene or creates a new game object with component T.
+    /// </summary>
+    /// <param name="onlyFind">
+    /// True if only FindObjectOfType should be called and if not found,
+    /// return null. False to find or create a new instance.
+    /// </param>
+    /// <returns>
+    /// Found or new instance. Null if <paramref name="onlyFind"/> == true and
+    /// FindObjectOfType returns null.
+    /// </returns>
     private static T FindOrCreateInstance( bool onlyFind = false )
     {
       if ( s_instance != null )
         Debug.LogError( $"{s_instance.name}: Invalid to call FindOrCreateInstance called with non-null s_instance." );
 
-      if ( IsDestroyed )
-        Debug.LogWarning( $"{typeof( T ).FullName}: IsDestroyed == true and finding/creating a new instance." );
+      // It's important that the caller knows something in which context
+      // the Instance call is made in so that we're not recreating this
+      // object in, e.g., OnDestroy/Unloading of as scene.
+      s_wasCreated = false;
 
       Instance = FindObjectOfType<T>();
-      Debug.Log( $"Found in scene: {typeof( T ).FullName}, {s_instance != null}" );
-      if ( !onlyFind && s_instance == null ) {
+      if ( !onlyFind && s_instance == null )
         Instance = new GameObject( typeof( T ).FullName ).AddComponent<T>();
-        Debug.Log( $"Create new: {typeof( T ).FullName}, {s_instance != null}" );
-      }
 
       if ( s_instance != null ) {
         s_instance.transform.hideFlags = HideFlags.NotEditable;
@@ -173,13 +120,11 @@ namespace AGXUnity
 
     private static void OnSceneUnloaded( Scene scene )
     {
-      Debug.Log( "OnSceneUnloaded: " + scene.name );
       s_wasCreated = false;
       SceneManager.sceneUnloaded -= OnSceneUnloaded;
     }
 
     private static T s_instance = null;
     private static bool s_wasCreated = false;
-#endif
   }
 }

--- a/AGXUnity/UniqueGameObject.cs
+++ b/AGXUnity/UniqueGameObject.cs
@@ -152,6 +152,9 @@ namespace AGXUnity
       if ( s_instance != null )
         Debug.LogError( $"{s_instance.name}: Invalid to call FindOrCreateInstance called with non-null s_instance." );
 
+      if ( IsDestroyed )
+        Debug.LogWarning( $"{typeof( T ).FullName}: IsDestroyed == true and finding/creating a new instance." );
+
       Instance = FindObjectOfType<T>();
       Debug.Log( $"Found in scene: {typeof( T ).FullName}, {s_instance != null}" );
       if ( !onlyFind && s_instance == null ) {

--- a/AGXUnity/UniqueGameObject.cs
+++ b/AGXUnity/UniqueGameObject.cs
@@ -16,8 +16,10 @@ namespace AGXUnity
   /// If this object has been destroyed, Instance will return null!
   /// </summary>
   /// <typeparam name="T">Type of subclass.</typeparam>
-  public class UniqueGameObject<T> : ScriptComponent where T : ScriptComponent
+  public class UniqueGameObject<T> : ScriptComponent
+    where T : ScriptComponent
   {
+#if OLD_SINGLETON
     protected static T m_instance     = null;
     protected static bool m_destroyed = false;
 
@@ -53,7 +55,10 @@ namespace AGXUnity
       }
     }
 
-    public static bool HasInstance { get { return m_instance != null || (FindObjectOfType( typeof( T ) ) as T ) != null; } }
+    // (FindObjectOfType( typeof( T ) ) as T ) != null
+    public static bool HasInstance => m_instance != null;
+
+    public static bool InstanceFound => m_instance != null || ( FindObjectOfType( typeof( T ) ) as T ) != null;
 
     public static bool IsDestroyed { get { return m_destroyed; } }
 
@@ -68,6 +73,8 @@ namespace AGXUnity
       m_destroyed = false;
     }
 
+    protected virtual bool OnInitialize() => true;
+
     protected override void OnAwake()
     {
       m_destroyed = false;
@@ -75,11 +82,25 @@ namespace AGXUnity
       base.OnAwake();
     }
 
+    protected sealed override bool Initialize()
+    {
+      // TODO: This isn't the right way to do it. Refactor this class!
+      // https://gamedev.stackexchange.com/questions/116009/in-unity-how-do-i-correctly-implement-the-singleton-pattern
+      int WARNING_READ_TODO;
+      if ( !OnInitialize() )
+        return false;
+
+      if ( m_instance == null )
+        m_instance = this as T;
+
+      return true;
+    }
+
     protected override void OnDestroy()
     {
-      base.OnDestroy();
-
       m_destroyed = true;
+
+      base.OnDestroy();
     }
 
     private static void OnSceneUnloaded( Scene scene )
@@ -87,5 +108,75 @@ namespace AGXUnity
       ResetDestroyedState();
       SceneManager.sceneUnloaded -= OnSceneUnloaded;
     }
+#else
+    public static T Instance
+    {
+      get
+      {
+        return s_instance ?? FindOrCreateInstance();
+      }
+      private set
+      {
+        s_instance = value;
+        s_wasCreated |= value != null;
+      }
+    }
+
+    public static bool HasInstance => s_instance != null;
+
+    public static bool IsDestroyed => s_wasCreated && s_instance == null;
+
+    public static bool HasInstanceInScene
+    {
+      get
+      {
+        return s_instance != null || ( FindOrCreateInstance( true ) != null );
+      }
+    }
+
+    protected sealed override void OnAwake()
+    {
+      Instance = this as T;
+    }
+
+    protected override void OnDestroy()
+    {
+      Debug.Log( $"OnDestroy: {typeof( T ).FullName}, {s_instance != null}" );
+      Instance = null;
+
+      base.OnDestroy();
+    }
+
+    private static T FindOrCreateInstance( bool onlyFind = false )
+    {
+      if ( s_instance != null )
+        Debug.LogError( $"{s_instance.name}: Invalid to call FindOrCreateInstance called with non-null s_instance." );
+
+      Instance = FindObjectOfType<T>();
+      Debug.Log( $"Found in scene: {typeof( T ).FullName}, {s_instance != null}" );
+      if ( !onlyFind && s_instance == null ) {
+        Instance = new GameObject( typeof( T ).FullName ).AddComponent<T>();
+        Debug.Log( $"Create new: {typeof( T ).FullName}, {s_instance != null}" );
+      }
+
+      if ( s_instance != null ) {
+        s_instance.transform.hideFlags = HideFlags.NotEditable;
+        s_wasCreated = true;
+        SceneManager.sceneUnloaded += OnSceneUnloaded;
+      }
+
+      return s_instance;
+    }
+
+    private static void OnSceneUnloaded( Scene scene )
+    {
+      Debug.Log( "OnSceneUnloaded: " + scene.name );
+      s_wasCreated = false;
+      SceneManager.sceneUnloaded -= OnSceneUnloaded;
+    }
+
+    private static T s_instance = null;
+    private static bool s_wasCreated = false;
+#endif
   }
 }

--- a/AGXUnity/WindAndWaterParameters.cs
+++ b/AGXUnity/WindAndWaterParameters.cs
@@ -89,7 +89,7 @@ namespace AGXUnity
 
     protected override bool Initialize()
     {
-      if ( !WindAndWaterManager.HasInstance )
+      if ( !WindAndWaterManager.HasInstanceInScene )
         return false;
 
       m_objects = Find.LeafObjects( gameObject, PropagateToChildren );

--- a/Editor/AGXUnityEditor/Manager.cs
+++ b/Editor/AGXUnityEditor/Manager.cs
@@ -681,16 +681,6 @@ namespace AGXUnityEditor
       Debug.LogWarning( "AGX Dynamics for Unity is currently updating..." );
       return EnvironmentState.Updating;
 #else
-      // WARNING INFO:
-      //     Unity 2018, 2019: AGX Dynamics for Unity compiles but undefined behavior
-      //                       in players with API compatibility @ .NET Standard 2.0.
-      //     Unity 2017: AGX Dynamics for Unity won't compile due to 
-      if ( PlayerSettings.GetApiCompatibilityLevel( BuildTargetGroup.Standalone ) != ApiCompatibilityLevel.NET_4_6 ) {
-        Debug.LogWarning( AGXUnity.Utils.GUI.AddColorTag( "<b>WARNING:</b> ", Color.yellow ) +
-                          "AGX Dynamics for Unity requires .NET API compatibility level: .NET 4.x.\n" +
-                          "<b>Edit -> Project Settings... -> Player -> Other Settings -> Configuration -> Api Compatibility Level -> .NET 4.x</b>" );
-      }
-
       // Running from within the editor - two options:
       //   1. Unity has been started from an AGX environment => do nothing.
       //   2. AGX Dynamics dll's are present in the plugins directory => setup
@@ -754,9 +744,24 @@ namespace AGXUnityEditor
         return EnvironmentState.Uninitialized;
       }
 
+      // WARNING INFO:
+      //     Unity 2018, 2019: AGX Dynamics for Unity compiles but undefined behavior
+      //                       in players with API compatibility @ .NET Standard 2.0.
+      if ( PlayerSettings.GetApiCompatibilityLevel( BuildTargetGroup.Standalone ) != ApiCompatibilityLevel.NET_4_6 ) {
+        var apiCompatibilityLevelName =
+#if UNITY_2021_2_OR_NEWER
+          ".NET Framework";
+#else
+          ".NET 4.x";
+#endif
+        Debug.LogWarning( AGXUnity.Utils.GUI.AddColorTag( "<b>WARNING:</b> ", Color.yellow ) +
+                          $"AGX Dynamics for Unity requires .NET API compatibility level: {apiCompatibilityLevelName}.\n" +
+                          $"<b>Edit -> Project Settings... -> Player -> Other Settings -> Configuration -> Api Compatibility Level -> {apiCompatibilityLevelName}</b>" );
+      }
+
       return EnvironmentState.Initialized;
 #endif
-    }
+      }
 
     private static bool HandleScriptReload( bool success )
     {

--- a/Editor/AGXUnityEditor/Menus/TopMenu.cs
+++ b/Editor/AGXUnityEditor/Menus/TopMenu.cs
@@ -462,9 +462,6 @@ namespace AGXUnityEditor
         return null;
       }
 
-      if ( UniqueGameObject<T>.Instance == null )
-        UniqueGameObject<T>.ResetDestroyedState();
-
       T obj = UniqueGameObject<T>.Instance;
       if ( !hadInstance && obj != null )
         Undo.RegisterCreatedObjectUndo( obj.gameObject, "Created " + obj.name );

--- a/Editor/AGXUnityEditor/Tools/CableTool.cs
+++ b/Editor/AGXUnityEditor/Tools/CableTool.cs
@@ -105,7 +105,13 @@ namespace AGXUnityEditor.Tools
           var wrappers = PropertyWrapper.FindProperties<CableProperty>( System.Reflection.BindingFlags.Instance |
                                                                         System.Reflection.BindingFlags.Public );
           foreach ( var wrapper in wrappers ) {
-            if ( wrapper.GetContainingType() == typeof( float ) && InspectorEditor.ShouldBeShownInInspector( wrapper.Member ) ) {
+            // Poisson's ratio is only used in the Twist direction and
+            // has HideInInspector in CableProperties. Overriding HideInInspector
+            // and rendering Poisson's ratio if dir == CableProperties.Direction.Twist.
+            var renderFloat = wrapper.GetContainingType() == typeof( float ) &&
+                              ( InspectorEditor.ShouldBeShownInInspector( wrapper.Member ) ||
+                                ( wrapper.Member.Name == "PoissonsRatio" && dir == CableProperties.Direction.Twist ) );
+            if ( renderFloat ) {
               var value = EditorGUILayout.FloatField( InspectorGUI.MakeLabel( wrapper.Member ),
                                                       wrapper.Get<float>( properties[ dir ] ) );
               if ( UnityEngine.GUI.changed ) {

--- a/Editor/AGXUnityEditor/Tools/Tool.cs
+++ b/Editor/AGXUnityEditor/Tools/Tool.cs
@@ -203,6 +203,11 @@ namespace AGXUnityEditor.Tools
     /// <param name="arrow">True to render as arrow, false to render as cylinder.</param>
     public void DebugRender( Vector3 start, Vector3 end, float radius, Color color, bool arrow = false )
     {
+      // Getting strange errors if we do this when the editor is
+      // going in or out of play mode.
+      if ( EditorApplication.isPlayingOrWillChangePlaymode != EditorApplication.isPlaying )
+        return;
+
       CreateDefaultDebugRenderable<Utils.VisualPrimitiveArrow>( color ).SetTransformEx( start,
                                                                                         end,
                                                                                         radius,
@@ -220,6 +225,9 @@ namespace AGXUnityEditor.Tools
     /// <param name="color">Color of sphere.</param>
     public void DebugRender( Vector3 center, float radius, Color color )
     {
+      if ( EditorApplication.isPlayingOrWillChangePlaymode != EditorApplication.isPlaying )
+        return;
+
       CreateDefaultDebugRenderable<Utils.VisualPrimitiveSphere>( color ).SetTransform( center,
                                                                                        Quaternion.identity,
                                                                                        radius,


### PR DESCRIPTION
### Fixes
- Fixed performance degradation (in some scenes), introduced in 3.1.0, during scene unload.
- Fixed bug in `AGXUnity.Collide.Plane` where any initial rotation of the plane was applied twice. ([257ada4](https://github.com/Algoryx/AGXUnity/commit/257ada448b3c53420083bcb1961219451adb2300))
- Exposing Poisson's ratio in the Inspector under the "Twist" direction of cable properties. ([2e72ee7](https://github.com/Algoryx/AGXUnity/commit/2e72ee7921121f6b3d53c82c5de1f4fecf5a6dc6))
- Fixed crash in builds when `AGXUnity.PickHandler` manager was enabled. It's now safe for an `AGXUnity.ScriptComponent` to call AGX Dynamics in `OnAwake` and `OnEnable`. ([676d3ea](https://github.com/Algoryx/AGXUnity/commit/676d3ea8710bd288cb8c2bcbcc9758d46aeaffc7))
- Fixed potential crash in `AGXUnity.PickHandler` manager when line/ray collision detection resulted in contacts with zero contact points. ([2b89c28](https://github.com/Algoryx/AGXUnity/commit/2b89c284674e881cf3bf26b883e7e1be785100a1))