### PR TITLE
URDF importer fix

### DIFF
--- a/AGXUnity/IO/URDF/Options.cs
+++ b/AGXUnity/IO/URDF/Options.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using UnityEngine;
+
 namespace AGXUnity.IO.URDF
 {
   public static class Options
@@ -8,5 +9,31 @@ namespace AGXUnity.IO.URDF
     /// by Unity that has to be reverted.
     /// </summary>
     public static bool TransformCollada { get; set; } = true;
+
+    /// <summary>
+    /// The Unity URDF importer includes a Collada asset processor that
+    /// transforms Collada assets in the project. This means that we have
+    /// to take into account if that package is installed and "undo" the
+    /// additional transformations made by that asset processor.
+    ///
+    /// In the Editor, this property will detect if the importer is installed
+    /// but it's possible to override this option by setting the desired value.
+    /// </summary>
+    public static bool UnityURDFImporterInstalled
+    {
+      get
+      {
+        if ( Application.isEditor && s_unityUrdfImporterInstalled == null )
+          s_unityUrdfImporterInstalled = Environment.IsEditorPackageInstalled( "com.unity.robotics.urdf-importer" );
+
+        return s_unityUrdfImporterInstalled ?? false;
+      }
+      set
+      {
+        s_unityUrdfImporterInstalled = value;
+      }
+    }
+
+    private static bool? s_unityUrdfImporterInstalled;
   }
 }


### PR DESCRIPTION
### Fixes
- Fixed URDF importer loading Collada resources when the Unity URDF importer package is installed. The Unity URDF importer has a custom Collada `AssetPostprocessor` which applies additional transforms to the Collada models in the project. This fix is reverting these additional transforms **on instances** used in our imported models. Both URDF importer plugins should work as expected when both are installed. ([c626af3](https://github.com/Algoryx/AGXUnity/commit/c626af33f80cb377109d5a02747a351114188f24))