### PR TITLE
Improved license validation when a license is loaded from a script

### DIFF
--- a/AGXUnity/GearConstraint.cs
+++ b/AGXUnity/GearConstraint.cs
@@ -67,10 +67,8 @@ namespace AGXUnity
 
     protected override bool Initialize()
     {
-      if ( !agx.Runtime.instance().isModuleEnabled( "AgX-DriveTrain" ) ) {
-        Debug.LogWarning( "GearConstraint requires a valid license for the AGX Dynamics module: AgX-DriveTrain", this );
+      if ( !LicenseManager.LicenseInfo.HasModuleLogError( LicenseInfo.Module.AGXDriveTrain, this ) )
         return false;
-      }
 
       if ( BeginActuatorConstraint?.GetInitialized<Constraint>() == null ) {
         Debug.LogError( "Invalid GearConstraint: Begin actuator constraint is invalid or null.", this );

--- a/AGXUnity/NativeHandler.cs
+++ b/AGXUnity/NativeHandler.cs
@@ -72,9 +72,6 @@ namespace AGXUnity
 
         if ( string.IsNullOrEmpty( envInstance.findComponent( "Referenced.agxEntity" ) ) )
           throw new AGXUnity.Exception( "Unable to find Components directory in RUNTIME_PATH." );
-
-        if ( !LicenseManager.LoadFile() )
-          LicenseManager.ActivateEncryptedRuntime( dataPluginsPath );
       }
 
       agx.agxSWIG.setEntityCreationThreadSafe( true );
@@ -99,6 +96,11 @@ namespace AGXUnity
     NativeHandler()
     {
       m_isAgx = new InitShutdownAGXDynamics();
+
+      if ( !Application.isEditor && m_isAgx.Initialized ) {
+        if ( !LicenseManager.LoadFile() )
+          LicenseManager.ActivateEncryptedRuntime( IO.Environment.GetPlayerPluginPath( Application.dataPath ) );
+      }
 
       // The environment probably hasn't been completely configured
       // when inside the editor so it's up to Manager to call
@@ -187,7 +189,7 @@ namespace AGXUnity
         return false;
       }
 
-      return (HasValidLicense = agx.Runtime.instance().verifyAndUnlock( licenseStr ));
+      return LicenseManager.Load( licenseStr );
     }
 
     #region Singleton Stuff
@@ -201,6 +203,8 @@ namespace AGXUnity
         return s_instance;
       }
     }
+
+    public static bool HasInstance => s_instance != null;
     #endregion
 
     private InitShutdownAGXDynamics m_isAgx = null;

--- a/AGXUnity/UniqueGameObject.cs
+++ b/AGXUnity/UniqueGameObject.cs
@@ -23,7 +23,9 @@ namespace AGXUnity
     {
       get
       {
-        return s_instance ?? FindOrCreateInstance();
+        return s_instance != null ?
+                 s_instance :
+                 FindOrCreateInstance();
       }
       private set
       {

--- a/Editor/AGXUnityEditor/DragDropListener.cs
+++ b/Editor/AGXUnityEditor/DragDropListener.cs
@@ -1,0 +1,73 @@
+﻿using System.IO;
+using System.Linq;
+using UnityEngine;
+using UnityEditor;
+
+namespace AGXUnityEditor
+{
+  [InitializeOnLoad]
+  public static class DragDropListener
+  {
+    public delegate void GameObjectArrayCallback( GameObject[] droppedInstances );
+
+    public static GameObjectArrayCallback OnPrefabsDroppedInScene;
+
+    static DragDropListener()
+    {
+      Selection.selectionChanged += OnSelectionChanged;
+      EditorApplication.update += OnUpdate;
+    }
+
+    private static void OnUpdate()
+    {
+      // Holding assets.
+      if ( DragAndDrop.paths.Length > 0 ) {
+        if ( IsValidDragState( DragAndDrop.visualMode ) ) {
+          if ( s_assetDragData == null )
+            s_assetDragData = PrefabAssetDragData.Create( DragAndDrop.paths );
+        }
+        else
+          s_assetDragData = null;
+      }
+    }
+
+    private static void OnSelectionChanged()
+    {
+      if ( s_assetDragData != null ) {
+        var selection = Selection.GetFiltered<GameObject>( SelectionMode.Editable | SelectionMode.TopLevel )
+                                 .Where( selected =>
+                                           s_assetDragData.Value.Prefabs.Contains( PrefabUtility.GetCorrespondingObjectFromSource( selected ) ) ).ToArray();
+        if ( selection.Length > 0 )
+          OnPrefabsDroppedInScene.Invoke( selection );
+        s_assetDragData = null;
+      }
+    }
+
+    private static bool IsValidDragState( DragAndDropVisualMode visualMode )
+    {
+      return visualMode == DragAndDropVisualMode.Copy ||
+             visualMode == DragAndDropVisualMode.Link;
+    }
+
+    private struct PrefabAssetDragData
+    {
+      public static PrefabAssetDragData? Create( string[] assetPaths )
+      {
+        var paths = assetPaths.Where( path => Path.GetExtension( path ).ToLower() == ".prefab" );
+        if ( paths.Count() == 0 )
+          return null;
+
+        return new PrefabAssetDragData()
+        {
+          Paths = paths.ToArray(),
+          Prefabs = paths.Select( path => AssetDatabase.LoadAssetAtPath<GameObject>( path ) ).ToArray()
+        };
+      }
+
+      public string[] Paths;
+      public GameObject[] Prefabs;
+    }
+
+    private static PrefabAssetDragData? s_assetDragData = null;
+  }
+}

--- a/Editor/AGXUnityEditor/DragDropListener.cs.meta
+++ b/Editor/AGXUnityEditor/DragDropListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ebbbc50b701c93488e6fcd175ba2cd6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AGXUnityEditor/Manager.cs
+++ b/Editor/AGXUnityEditor/Manager.cs
@@ -95,6 +95,8 @@ namespace AGXUnityEditor
 
       Selection.selectionChanged += OnSelectionChanged;
 
+      DragDropListener.OnPrefabsDroppedInScene += OnPrefabsDroppedInScene;
+
       while ( VisualsParent != null && VisualsParent.transform.childCount > 0 )
         GameObject.DestroyImmediate( VisualsParent.transform.GetChild( 0 ).gameObject );
 
@@ -118,7 +120,8 @@ namespace AGXUnityEditor
       InspectorWindow,
       SceneHierarchyWindow,
       SceneView,
-      GameView
+      GameView,
+      ProjectBrowser
     }
 
     /// <summary>
@@ -385,16 +388,29 @@ namespace AGXUnityEditor
       // their parent is though (since selection is included in undo/redo),
       // so find shapes in children of the selection and access bodies
       // from there as well.
-      var shapesInSelection = Selection.GetFiltered<GameObject>( SelectionMode.TopLevel |
+      //
+      // Note that UpdateMassProperties is a time consuming operation. Ideally
+      // we would like to know if operations has been made that affects the
+      // mass properties of bodies.
+      var bodiesInSelection = Selection.GetFiltered<GameObject>( SelectionMode.TopLevel |
                                                                  SelectionMode.Editable )
-                                       .SelectMany( go => go.GetComponentsInChildren<AGXUnity.Collide.Shape>() );
+                                       .SelectMany( go => go.GetComponentsInChildren<AGXUnity.RigidBody>() );
+      var shapesInSelection = bodiesInSelection.SelectMany( rb => rb.Shapes );
       foreach ( var shape in shapesInSelection ) {
         var visual = AGXUnity.Rendering.ShapeVisual.Find( shape );
         if ( visual != null )
           visual.OnSizeUpdated();
+      }
 
-        var rb = shape.RigidBody;
-        if ( rb != null )
+      // Looking at the number of shapes to begin with because it can
+      // be one rigid body with many shapes. The thing is that the
+      // undo/redo operation is highly unlikely to be affecting the
+      // mass properties. And note that the mass properties won't be
+      // wrong in the simulation due to this, only displayed wrong
+      // until simulation.
+      var updateMassProperties = shapesInSelection.Count() < 32;
+      if ( updateMassProperties ) {
+        foreach ( var rb in bodiesInSelection )
           rb.UpdateMassProperties();
       }
 
@@ -574,21 +590,6 @@ namespace AGXUnityEditor
 
         AutoUpdateSceneHandler.HandleUpdates( scene );
       }
-      else if ( Selection.activeGameObject != null ) {
-        var isPrefabInstance = PrefabUtility.GetPrefabInstanceStatus( Selection.activeGameObject ) != PrefabInstanceStatus.NotAPrefab;
-
-        // We want to catch when a prefab has been instantiated in the
-        // scene. Maybe this feature should be explicit, i.e., some
-        // method doing the work.
-        // NOTE: We receive callbacks to OnHierarchyWindowChanged when a
-        //       component is added and when the undo/redo is performed.
-        //       To not screw up the undo/redo history we block this feature
-        //       when undo/redo has been made close in time.
-        // TODO: Make this work - OnHierarchyWindowChanged is not a good place
-        //       to instantiate additional things.
-        if ( isPrefabInstance && ( EditorApplication.timeSinceStartup - s_lastUndoRedoTime ) > 2.0 )
-          AssetPostprocessorHandler.OnPrefabAddedToScene( Selection.activeGameObject );
-      }
 
       m_numScenesLoaded = EditorSceneManager.loadedSceneCount;
     }
@@ -596,7 +597,7 @@ namespace AGXUnityEditor
     /// <summary>
     /// Previous selection used to reset used EditorDataEntry entries.
     /// </summary>
-    private static UnityEngine.Object[] m_previousSelection = new UnityEngine.Object[] { };
+    private static Object[] m_previousSelection = new Object[] { };
 
     /// <summary>
     /// Editor data entry for "SelectedInHierarchy" property.
@@ -660,6 +661,27 @@ namespace AGXUnityEditor
       if ( Selection.objects.Length == 0 )
         ToolManager.ReleaseAllRecursiveEditors();
     }
+
+    private static void OnPrefabsDroppedInScene( GameObject[] instances )
+    {
+      var ourInstances = instances.Where( instance =>
+                                            instance != null &&
+                                            ( instance.GetComponentInChildren<AGXUnity.IO.RestoredAGXFile>() != null ||
+                                              instance.GetComponentInChildren<AGXUnity.IO.SavedPrefabLocalData>() != null ) );
+      if ( ourInstances.Count() == 0 )
+        return;
+
+      foreach ( var instance in ourInstances )
+        Undo.ClearUndo( instance );
+
+      Undo.SetCurrentGroupName( "Adding prefab instance(s) to scene." );
+      var groupId = Undo.GetCurrentGroup();
+      foreach ( var instance in ourInstances ) {
+        AssetPostprocessorHandler.OnPrefabAddedToScene( instance );
+      }
+      Undo.CollapseUndoOperations( groupId );
+    }
+
 
     private static void HandleWindowsGUI( SceneView sceneView )
     {

--- a/Editor/AGXUnityEditor/Menus/TopMenu.cs
+++ b/Editor/AGXUnityEditor/Menus/TopMenu.cs
@@ -456,7 +456,7 @@ namespace AGXUnityEditor
     public static T GetOrCreateUniqueGameObject<T>()
       where T : ScriptComponent
     {
-      bool hadInstance = UniqueGameObject<T>.HasInstance;
+      bool hadInstance = UniqueGameObject<T>.HasInstanceInScene;
       if ( !hadInstance && AGXUnity.Utils.PrefabUtils.IsEditingPrefab ) {
         Debug.LogWarning( $"Invalid to create {typeof( T ).FullName} while editing prefabs." );
         return null;


### PR DESCRIPTION
### Fixes
- Improved license activation/loading from scripts in projects where there are no license files. ([c6a60d2](https://github.com/Algoryx/AGXUnity/commit/c6a60d29f69f0cd87c8cf0c404df9c8fc9b19204))
- Fixed `AGXUnity.UniqueGameObject<T>.Instance` to properly handle the case when the object has been deleted. ([346e802](https://github.com/Algoryx/AGXUnity/pull/83/commits/346e802e30dd5da349c560077b804c60033c41ee))
- Improved undo/redo performance by avoiding calculations of mass properties of rigid bodies if the selection includes many shapes. ([d60abb6](https://github.com/Algoryx/AGXUnity/pull/83/commits/d60abb63f303c3bf2fa84dadd7f8707aaefe2794))
- Improved undo/redo when imported prefabs are dragged and dropped into scenes. ([d60abb6](https://github.com/Algoryx/AGXUnity/pull/83/commits/d60abb63f303c3bf2fa84dadd7f8707aaefe2794), [1f8be95](https://github.com/Algoryx/AGXUnity/pull/83/commits/1f8be9500dca511351cacd7c7df26e45cbee2685))