### PR TITLE
ObserverFrame now sets the name of the native object and adds it to the simulation in Initialize

### DIFF
--- a/AGXUnity/ObserverFrame.cs
+++ b/AGXUnity/ObserverFrame.cs
@@ -27,10 +27,14 @@ namespace AGXUnity
     {
       Native = new agx.ObserverFrame();
 
+      Native.setName(name);
+
       var rb = gameObject.GetInitializedComponentInParent<RigidBody>();
       Native.attachWithWorldTransform( rb != null ? rb.Native : null,
                                        new agx.AffineMatrix4x4( transform.rotation.ToHandedQuat(),
                                                                 transform.position.ToHandedVec3() ) );
+
+      GetSimulation().add(Native);
 
       return true;
     }

--- a/AGXUnity/ObserverFrame.cs
+++ b/AGXUnity/ObserverFrame.cs
@@ -1,5 +1,5 @@
-﻿using UnityEngine;
-using AGXUnity.Utils;
+﻿using AGXUnity.Utils;
+using UnityEngine;
 
 namespace AGXUnity
 {
@@ -8,7 +8,7 @@ namespace AGXUnity
   /// to communicate reference transforms. This object is often
   /// only created when reading .agx files.
   /// </summary>
-  [AddComponentMenu( "AGXUnity/Observer Frame" )]
+  [AddComponentMenu("AGXUnity/Observer Frame")]
   public class ObserverFrame : ScriptComponent
   {
     /// <summary>
@@ -16,9 +16,9 @@ namespace AGXUnity
     /// </summary>
     public agx.ObserverFrame Native { get; private set; } = null;
 
-    public void RestoreLocalDataFrom( agx.ObserverFrame native, GameObject parent )
+    public void RestoreLocalDataFrom(agx.ObserverFrame native, GameObject parent)
     {
-      transform.SetParent( parent != null ? parent.transform : null );
+      transform.SetParent(parent != null ? parent.transform : null);
       transform.position = native.getPosition().ToHandedVector3();
       transform.rotation = native.getRotation().ToHandedQuaternion();
     }
@@ -30,13 +30,22 @@ namespace AGXUnity
       Native.setName(name);
 
       var rb = gameObject.GetInitializedComponentInParent<RigidBody>();
-      Native.attachWithWorldTransform( rb != null ? rb.Native : null,
-                                       new agx.AffineMatrix4x4( transform.rotation.ToHandedQuat(),
-                                                                transform.position.ToHandedVec3() ) );
+      Native.attachWithWorldTransform(rb != null ? rb.Native : null,
+                                       new agx.AffineMatrix4x4(transform.rotation.ToHandedQuat(),
+                                                                transform.position.ToHandedVec3()));
 
       GetSimulation().add(Native);
 
       return true;
+    }
+
+    protected override void OnDestroy()
+    {
+      if (Simulation.HasInstance)
+        GetSimulation().remove(Native);
+      
+      Native = null;
+      base.OnDestroy();
     }
   }
 }


### PR DESCRIPTION
ObserverFrames created in Unity now sets the name of the underlying Native object and adds it to the Simulation.

This fixes issues caused by querying the simulation for ObserverFrames based on their name.