### PR TITLE
Minor features and fixes

### DIFF
--- a/AGXUnity/AttachmentPair.cs
+++ b/AGXUnity/AttachmentPair.cs
@@ -197,6 +197,11 @@ namespace AGXUnity
       return true;
     }
 
+    protected virtual void Reset()
+    {
+      hideFlags |= HideFlags.HideInInspector;
+    }
+
     private AttachmentPair()
     {
     }

--- a/AGXUnity/ElementaryConstraint.cs
+++ b/AGXUnity/ElementaryConstraint.cs
@@ -181,5 +181,10 @@ namespace AGXUnity
 
       base.OnDestroy();
     }
+
+    protected virtual void Reset()
+    {
+      hideFlags |= HideFlags.HideInInspector;
+    }
   }
 }

--- a/AGXUnity/MassProperties.cs
+++ b/AGXUnity/MassProperties.cs
@@ -254,6 +254,11 @@ namespace AGXUnity
       return true;
     }
 
+    protected virtual void Reset()
+    {
+      hideFlags |= HideFlags.HideInInspector;
+    }
+
     /// <summary>
     /// Finds the native rigid body instance this mass properties belongs to.
     /// </summary>

--- a/AGXUnity/Route.cs
+++ b/AGXUnity/Route.cs
@@ -181,6 +181,11 @@ namespace AGXUnity
       base.OnDestroy();
     }
 
+    protected virtual void Reset()
+    {
+      hideFlags |= HideFlags.HideInInspector;
+    }
+
     private bool TryInsertAtIndex( int index, T node )
     {
       // According to List documentation having index == m_nodes.Count is

--- a/AGXUnity/Utils/OnSelectionProxy.cs
+++ b/AGXUnity/Utils/OnSelectionProxy.cs
@@ -20,5 +20,10 @@ namespace AGXUnity.Utils
       get { return m_component; }
       set { m_component = value; }
     }
+
+    protected virtual void Reset()
+    {
+      hideFlags |= HideFlags.HideInInspector;
+    }
   }
 }

--- a/AGXUnity/Utils/PrefabUtils.cs
+++ b/AGXUnity/Utils/PrefabUtils.cs
@@ -53,5 +53,22 @@ namespace AGXUnity.Utils
       StageUtility.PlaceGameObjectInCurrentStage( gameObject );
 #endif
     }
+
+    /// <summary>
+    /// Finds if <paramref name="componentOrGameObject"/> is part of a prefab
+    /// instance, i.e., selected in the Hierarchy of a scene. This method
+    /// returns false when the object is selected in the Hierarchy inside
+    /// the Prefab Stage.
+    /// </summary>
+    /// <param name="componentOrGameObject">Component or game object to check.</param>
+    /// <returns>True if the component or game object is part of a prefab instance.</returns>
+    public static bool IsPrefabInstance( Object componentOrGameObject )
+    {
+#if UNITY_EDITOR
+      return UnityEditor.PrefabUtility.GetPrefabInstanceStatus( componentOrGameObject ) == UnityEditor.PrefabInstanceStatus.Connected;
+#else
+      return false;
+#endif
+    }
   }
 }

--- a/Editor/AGXUnityEditor/AutoUpdateSceneHandler.cs
+++ b/Editor/AGXUnityEditor/AutoUpdateSceneHandler.cs
@@ -33,7 +33,12 @@ namespace AGXUnityEditor
     public static bool VerifyPrefabInstance( GameObject instance )
     {
 #if UNITY_2018_3_OR_NEWER
-      var isDisconnected = PrefabUtility.IsDisconnectedFromPrefabAsset( instance );
+      var isDisconnected =
+#if UNITY_2022_1_OR_NEWER
+        false;
+#else
+        PrefabUtility.IsDisconnectedFromPrefabAsset( instance );
+#endif
 
       // Patching the instance when we've a disconnected prefab - otherwise patch
       // the source asset object.

--- a/Editor/AGXUnityEditor/InspectorEditor.cs
+++ b/Editor/AGXUnityEditor/InspectorEditor.cs
@@ -200,8 +200,15 @@ namespace AGXUnityEditor
       m_numTargetGameObjectsTargetComponents = m_targetGameObjects.Sum( go => go.GetComponents( m_targetType ).Length );
 
       // Entire class/component marked as hidden - enable "hide in inspector".
-      if ( this.target.GetType().GetCustomAttributes( typeof( HideInInspector ), false ).Length > 0 )
-        this.target.hideFlags |= HideFlags.HideInInspector;
+      // NOTE: This will break Inspector rendering in 2022.1 and later because changing
+      //       hideFlags here results in a destroy of all editors and the editors that
+      //       should be visible are enabled again but never rendered by Unity.
+      // SOLUTION: Add hideFlags |= HideFlags.HideInInspector in Reset method of the class
+      //           that shouldn't be rendered in the Inspector.
+      if ( this.targets.Any( t => !t.hideFlags.HasFlag( HideFlags.HideInInspector ) ) && m_targetType.GetCustomAttribute<HideInInspector>( false ) != null ) {
+        foreach ( var t in this.targets )
+          t.hideFlags |= HideFlags.HideInInspector;
+      }
 
       ToolManager.OnTargetEditorEnable( this.targets, this );
     }

--- a/Editor/AGXUnityEditor/Manager.cs
+++ b/Editor/AGXUnityEditor/Manager.cs
@@ -627,9 +627,15 @@ namespace AGXUnityEditor
     private static void OnHierarchyWindowChanged()
     {
       var scene = EditorSceneManager.GetActiveScene();
+      var currNumScenesLoaded =
+#if UNITY_2022_2_OR_NEWER
+                                UnityEngine.SceneManagement.SceneManager.loadedSceneCount;
+#else
+                                EditorSceneManager.loadedSceneCount;
+#endif
       var isSceneLoaded = scene.name != m_currentSceneName ||
                           // Drag drop of scene into hierarchy.
-                          EditorSceneManager.loadedSceneCount > m_numScenesLoaded;
+                          currNumScenesLoaded > m_numScenesLoaded;
 
       if ( isSceneLoaded ) {
         EditorData.Instance.GC();
@@ -639,7 +645,7 @@ namespace AGXUnityEditor
         AutoUpdateSceneHandler.HandleUpdates( scene );
       }
 
-      m_numScenesLoaded = EditorSceneManager.loadedSceneCount;
+      m_numScenesLoaded = currNumScenesLoaded;
     }
 
     /// <summary>

--- a/Editor/AGXUnityEditor/Tools/ShapeMeshTool.cs
+++ b/Editor/AGXUnityEditor/Tools/ShapeMeshTool.cs
@@ -121,6 +121,10 @@ namespace AGXUnityEditor.Tools
       using ( new GUI.EnabledBlock( !EditorApplication.isPlayingOrWillChangePlaymode ) ) {
         if ( InspectorGUI.Foldout( GetEditorData( Mesh ), GUI.MakeLabel( "Options" ) ) ) {
           using ( InspectorGUI.IndentScope.Single ) {
+            if ( GetTargets<AGXUnity.Collide.Mesh>().Any( mesh => PrefabUtils.IsPrefabInstance( mesh ) ) )
+              InspectorGUI.WarningLabel( "WARNING!\n\nEditing mesh Options on a prefab <b>instance</b> may cause the Editor to hang\n" +
+                                         "due to extensive prefab Overrides.\n\nConsider making the changes in the <b>Prefab Stage</b> instead." );
+
             InspectorEditor.DrawMembersGUI( Targets, t => ( t as AGXUnity.Collide.Mesh ).Options );
             var applyResetResult = InspectorGUI.PositiveNegativeButtons( UnityEngine.GUI.enabled,
                                                                          "Apply",

--- a/Resources/Input/AGXUnityInputControls.inputactions
+++ b/Resources/Input/AGXUnityInputControls.inputactions
@@ -11,7 +11,8 @@
                     "id": "8607ec06-2d43-4d5c-8cca-886a93e1d1ed",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Brake",
@@ -19,7 +20,8 @@
                     "id": "854a3dfd-dfff-4232-8213-a88ea3df66df",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Steer",
@@ -27,7 +29,8 @@
                     "id": "d270e7f3-6cd7-462c-b73c-e9375b5a7330",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Elevate",
@@ -35,7 +38,8 @@
                     "id": "16c9244b-26fc-41b4-9410-2802b8d3b3ab",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Tilt",
@@ -43,7 +47,8 @@
                     "id": "3b2813ae-d2fa-465d-892f-ac4b9ec5bdce",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -107,7 +112,7 @@
                     "id": "6e59ebb4-6dac-4408-9c3a-e040f041bf8e",
                     "path": "<Keyboard>/a",
                     "interactions": "",
-                    "processors": "",
+                    "processors": "Invert",
                     "groups": "",
                     "action": "Steer",
                     "isComposite": false,
@@ -118,7 +123,7 @@
                     "id": "bfdaf6d8-6624-4c5f-92a7-aa822960c5b9",
                     "path": "<Keyboard>/d",
                     "interactions": "",
-                    "processors": "Invert",
+                    "processors": "",
                     "groups": "",
                     "action": "Steer",
                     "isComposite": false,
@@ -202,7 +207,8 @@
                     "id": "613a10a0-1ae3-421b-910f-2c38e474e68e",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Brake",
@@ -210,7 +216,8 @@
                     "id": "5d5ed8e0-6d18-4595-b532-5a721dd0fdb2",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Steer",
@@ -218,7 +225,8 @@
                     "id": "f5da6fbb-67bd-449b-a968-0b2e03983112",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Drive",
@@ -226,7 +234,8 @@
                     "id": "8bece246-ff0a-4e5c-bce3-6faeab92c0ad",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Bucket",
@@ -234,7 +243,8 @@
                     "id": "6bb0c0a5-c1d6-4e2f-8fb3-5e27396a0cb9",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Stick",
@@ -242,7 +252,8 @@
                     "id": "3c8f261e-6b86-4a58-a4e6-4b5d1971b5f0",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Boom",
@@ -250,7 +261,8 @@
                     "id": "1a71b492-e6cc-453a-95fb-4e81b42af0e5",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Cabin",
@@ -258,7 +270,8 @@
                     "id": "d18268c2-7518-4080-b9fe-050745bcfc78",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -516,7 +529,8 @@
                     "id": "592be0dc-75b8-43e0-bb80-fb18ffc3b101",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Open",
@@ -524,7 +538,8 @@
                     "id": "1272376c-9b06-4509-9fdd-c4f1f41cdc98",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "RotateWristRight",
@@ -532,7 +547,8 @@
                     "id": "52788b92-0083-4144-9f84-9fb45a00e62c",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "RotateWristLeft",
@@ -540,7 +556,8 @@
                     "id": "4541a65a-e846-4452-873f-4f7ed0834bce",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "UpDown",
@@ -548,7 +565,8 @@
                     "id": "8fc53972-c79c-4d1b-9249-f3890b94f223",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "LeftRight",
@@ -556,7 +574,8 @@
                     "id": "87dc55c0-95fd-435f-a319-6b3ae0ea6162",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "ForwardBackward",
@@ -564,7 +583,8 @@
                     "id": "4515f61e-f3d2-46cf-8cdf-c88807b817a9",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Hinge2",
@@ -572,7 +592,8 @@
                     "id": "14016bed-0ef6-44f7-9bed-3c432924c54d",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 },
                 {
                     "name": "Hinge3",
@@ -580,7 +601,8 @@
                     "id": "5e1bd515-cbee-4bc6-a43a-5ad89782f104",
                     "expectedControlType": "",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [


### PR DESCRIPTION
### Features
- Added support for 32-bit vertex index format in `AGXUnity.Utils.MeshSplitter` which automatically changes the index format if the vertex count exceeds 65535. This means import (`.agx`) of large meshes won't split unless the vertex count exceeds 4 billion. ([affb542](https://github.com/Algoryx/AGXUnity/commit/affb542e45e656b1dd5da08c63c84b57bd9f7da4))
- Added distinct warning in the Inspector of `AGXUnity.Collide.Mesh` Collision Mesh Options when the selection includes a **prefab instance**. Collision mesh creations/modifications should be applied to the actual prefab in the Prefab Stage to avoid extensive Prefab Overrides. ([bd52e02](https://github.com/Algoryx/AGXUnity/commit/bd52e02932b0cc4362e9be8598dba5c48494d44b))

### Fixes
- Fixed issue where Inspector Editors broke when the `HideInInspector` attribute was set on a class. Unity 2022.1 and later no long supports changing `hideFlags` from within a custom editor. ([f8b4807](https://github.com/Algoryx/AGXUnity/commit/f8b480795dd58bbf8fc87326ba2f792b5cee330c))
- Fixed bug in re-import of `.agx` files where new render materials should be created. ([affb542](https://github.com/Algoryx/AGXUnity/commit/affb542e45e656b1dd5da08c63c84b57bd9f7da4))
- Fixed deprecated warnings in Unity 2022.x. ([a63ec4c](https://github.com/Algoryx/AGXUnity/commit/a63ec4c3762f018c671d4a4a422570a393415606), [5bef842](https://github.com/Algoryx/AGXUnity/commit/5bef842cbcd0635e8d3cd47068c326e19504fd3e))
- Fixed key bindings so `a` is left and `d` is right in examples using `AGXUnityInputControls`. ([4fb814b](https://github.com/Algoryx/AGXUnity/commit/4fb814b17458bd7e49c10090c9a1f401b7a1dbaf))