### PR TITLE
Added reminders to add contact material to manager in ContactMaterial editor

### DIFF
--- a/Editor/AGXUnityEditor/Tools/ContactMaterialTool.cs
+++ b/Editor/AGXUnityEditor/Tools/ContactMaterialTool.cs
@@ -1,0 +1,46 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System.Linq;
+using AGXUnity;
+using AGXUnity.Collide;
+using AGXUnity.Utils;
+
+namespace AGXUnityEditor.Tools
+{
+  [CustomTool( typeof( ContactMaterial ) )]
+  class ContactMaterialTool : CustomTargetTool
+  {
+    public ContactMaterial ContactMaterial
+    {
+      get
+      {
+        return Targets[ 0 ] as ContactMaterial;
+      }
+    }
+
+    public ContactMaterialTool( Object[] targets )
+      : base( targets )
+    {
+    }
+
+    public override void OnPostTargetMembersGUI()
+    {
+      if(!ContactMaterialManager.HasInstanceInScene || !ContactMaterialManager.Instance.ContactMaterials.Contains(ContactMaterial)) {
+        InspectorGUI.Separator( 1, 16 );
+        var enabled = UnityEngine.GUI.enabled;
+        if ( !ContactMaterialManager.HasInstanceInScene ) {
+          EditorGUILayout.HelpBox( "The current scene does not contain a ContactMaterialManager object.", MessageType.Warning,true );
+          if ( GUILayout.Button( AGXUnity.Utils.GUI.MakeLabel( "Add a ContactMaterialManager to scene" ) ) ) {
+            _ = ContactMaterialManager.Instance;
+          }
+          UnityEngine.GUI.enabled = false;
+        }
+        EditorGUILayout.HelpBox( "Contact material has not been added to ContactMaterialManager and will not be used unless added through scripts at runtime.", MessageType.Warning, true );
+        if(GUILayout.Button( AGXUnity.Utils.GUI.MakeLabel( "Add material to ContactMaterialManager" ) ) ) {
+          ContactMaterialManager.Instance.Add( ContactMaterial );
+        }
+        UnityEngine.GUI.enabled = enabled;
+      }
+    }
+  }
+}

--- a/Editor/AGXUnityEditor/Tools/ContactMaterialTool.cs.meta
+++ b/Editor/AGXUnityEditor/Tools/ContactMaterialTool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b11135b10603995469ccbaa115168271
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds two warnings with corresponding _fix it_-buttons to the ContactMaterial inspector:

- If the scene does not contain a ContactMaterialManager a warning is displayed and a button is shown which adds a manager to the scene when pressed.
- If the scene's ContactMaterialManager does not contain the currently shown contact material (or the manager does not exist) a warning is displayed and a button is shown which adds the contact material to the manager (disabled if manager does not exist).

![ContactMaterialInspector](https://user-images.githubusercontent.com/114672787/219334418-cf03baa2-67ec-4277-9d19-cd2228deb775.png)
