### PR TITLE
Old ElementaryConstraint components are now destroyed when new are added

### DIFF
--- a/AGXUnity/Constraint.cs
+++ b/AGXUnity/Constraint.cs
@@ -636,6 +636,9 @@ namespace AGXUnity
       if ( native == null )
         throw new ArgumentNullException( "native", "Native constraint is null." );
 
+      // Remove old elementary constraint components
+      foreach ( var ec in m_elementaryConstraints )
+        DestroyImmediate( ec );
       m_elementaryConstraints.Clear();
 
       for ( uint i = 0; i < native.getNumElementaryConstraints(); ++i ) {
@@ -866,6 +869,11 @@ namespace AGXUnity
 
     protected override void OnDestroy()
     {
+      // Remove old elementary constraint components
+      foreach ( var ec in m_elementaryConstraints )
+        DestroyImmediate( ec );
+      m_elementaryConstraints.Clear();
+
       if ( Simulation.HasInstance ) {
         Simulation.Instance.StepCallbacks.PreSynchronizeTransforms -= OnPreStepForwardUpdate;
         GetSimulation().remove( Native );

--- a/AGXUnity/Constraint.cs
+++ b/AGXUnity/Constraint.cs
@@ -869,11 +869,6 @@ namespace AGXUnity
 
     protected override void OnDestroy()
     {
-      // Remove old elementary constraint components
-      foreach ( var ec in m_elementaryConstraints )
-        DestroyImmediate( ec );
-      m_elementaryConstraints.Clear();
-
       if ( Simulation.HasInstance ) {
         Simulation.Instance.StepCallbacks.PreSynchronizeTransforms -= OnPreStepForwardUpdate;
         GetSimulation().remove( Native );


### PR DESCRIPTION
So it seems that this issue is caused by the constraint component adding additional components for each elementary and secondary constraint that makes up the ordinary constraint. However, when the constraint is reimported, all elementary and secondary constraints are added again while the old ones are still on the GameObject. The result is that each time the constraint is reimported, a set of "dead constraints", which will never be initialized by the main constraint component, are left on the GameObject. When accessing the `TargetSpeedController` component via `GetComponent` or via Visual Scripting, the first constraint will be used. In the case where the constraint has been reimported, this constraint will be a dead constraint. 

This MR adds a component removal of the dead constraints when new constraints are added.