### PR TITLE
Fix import error for default material

### DIFF
--- a/AGXUnity/Utils/RenderingUtils.cs
+++ b/AGXUnity/Utils/RenderingUtils.cs
@@ -126,7 +126,18 @@ namespace AGXUnity.Utils
     /// <returns>A new material if the current render pipeline is recognized or null otherwise</returns>
     public static Material CreateDefaultMaterial()
     {
-      return new Material( Shader.Find( "AGXUnity/Shader Graph/CrossRPDefault" ) );
+       var shader = Shader.Find( "AGXUnity/Shader Graph/CrossRPDefault" );
+       if ( shader == null )
+       {
+          Debug.LogWarning( "AGXUnity/Shader Graph/CrossRPDefault shader not found. Falling back to Standard shader." );
+          shader = Shader.Find( "Standard" );
+       }
+       if ( shader == null )
+       {
+          Debug.LogError( "Failed to find any suitable shader for CreateDefaultMaterial." );
+          return null;
+       }
+       return new Material( shader );
     }
 
     /// <summary>


### PR DESCRIPTION
This error appears during initial import in the AssetPostprocessorHandler.OnPostprocessPrefab callback, which runs during asset import. Shader.Find() attempts to find the CrossRPDefault shader which is not yet loaded. This causes the Material constructor to throw an ArgumentNullException.

This is a non-issue past the first import so this fix it merely to suppress the error

```
ArgumentNullException: Value cannot be null.
Parameter name: shader
UnityEngine.Bindings.ThrowHelper.ThrowArgumentNullException (System.Object obj, System.String parameterName) (at <1b6535aa091d41cf8b3ca222ed9ceef0>:0)
UnityEngine.Material.CreateWithShader (UnityEngine.Material self, UnityEngine.Shader shader) (at <1b6535aa091d41cf8b3ca222ed9ceef0>:0)
UnityEngine.Material..ctor (UnityEngine.Shader shader) (at <1b6535aa091d41cf8b3ca222ed9ceef0>:0)
AGXUnity.Utils.RenderingUtils.CreateDefaultMaterial () (at Assets/AGXUnity/AGXUnity/Utils/RenderingUtils.cs:129)
AGXUnity.Rendering.WireRenderer.DefaultMaterial () (at Assets/AGXUnity/AGXUnity/Rendering/WireRenderer.cs:109)
AGXUnityEditor.AssetPostprocessorHandler.OnPostprocessPrefab (UnityEngine.GameObject gameObject) (at Assets/AGXUnity/Editor/AGXUnityEditor/AssetPostprocessorHandler.cs:65)
System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <41d29b352f6a475ab1bf7c6628b82790>:0)
Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) (at <41d29b352f6a475ab1bf7c6628b82790>:0)
System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) (at <41d29b352f6a475ab1bf7c6628b82790>:0)
UnityEditor.AssetPostprocessingInternal.InvokeMethodIfAvailable (System.Object target, System.String methodName, System.Object[] args) (at <2e4eaf245b924ed1b8c17467295ae042>:0)
UnityEditor.AssetPostprocessingInternal.CallPostProcessMethods (System.String methodName, System.Object[] args) (at <2e4eaf245b924ed1b8c17467295ae042>:0)
UnityEditor.AssetPostprocessingInternal.PostprocessPrefab (UnityEngine.GameObject prefabAssetRoot) (at <2e4eaf245b924ed1b8c17467295ae042>:0)

```